### PR TITLE
 optimize: 优化项目配置, 在编译器支持 C++17 的时候开启 C++17，并定义宏 EGE_ENABLE_CPP17=1, 内部代码可以通过这个宏定义来判断是否要走 C++17 逻辑

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,15 +3,17 @@
     "configurations": [
         {
             "name": "default",
-            "cStandard": "c11",
-            "cppStandard": "c++11",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
             "defines": [
                 "_FORTIFY_SOURCE=0"
             ],
             "includePath": [
                 "${workspaceFolder}/include",
+                "${workspaceFolder}/include/ege",
                 "${workspaceFolder}/3rdparty/libpng"
             ],
+            "configurationProvider": "ms-vscode.cmake-tools",
             "compilerArgs": [
                 "/Zc:__cplusplus"
             ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,7 +17,7 @@
                 "cwd": "${workspaceFolder}"
             },
             "group": "build",
-            "problemMatcher": "$gcc"
+            "problemMatcher": "$msCompile"
         },
         {
             "label": "Reload CMake Project",
@@ -33,7 +33,7 @@
                 "cwd": "${workspaceFolder}"
             },
             "group": "build",
-            "problemMatcher": "$gcc"
+            "problemMatcher": "$msCompile"
         },
         {
             "label": "Cleanup CMake Project",
@@ -48,7 +48,7 @@
                 "cwd": "${workspaceFolder}"
             },
             "group": "build",
-            "problemMatcher": "$gcc"
+            "problemMatcher": "$msCompile"
         },
         {
             "label": "Build XEGE Library",
@@ -66,7 +66,7 @@
                 "cwd": "${workspaceFolder}"
             },
             "group": "build",
-            "problemMatcher": "$gcc"
+            "problemMatcher": "$msCompile"
         },
         {
             "label": "Build Demos",
@@ -84,7 +84,7 @@
                 "cwd": "${workspaceFolder}"
             },
             "group": "build",
-            "problemMatcher": "$gcc"
+            "problemMatcher": "$msCompile"
         },
         {
             "label": "Build All",
@@ -135,7 +135,7 @@
                 "cwd": "${workspaceFolder}"
             },
             "group": "build",
-            "problemMatcher": "$gcc"
+            "problemMatcher": "$msCompile"
         },
         {
             "label": "Load And Build Demos",
@@ -154,7 +154,7 @@
                 "cwd": "${workspaceFolder}"
             },
             "group": "build",
-            "problemMatcher": "$gcc"
+            "problemMatcher": "$msCompile"
         },
         {
             "label": "Run Demo - XEGE Test",
@@ -234,7 +234,7 @@
                 "cwd": "${workspaceFolder}"
             },
             "group": "build",
-            "problemMatcher": "$gcc"
+            "problemMatcher": "$msCompile"
         }
     ]
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,43 @@ endif()
 
 project(XEGE)
 
+if(NOT DEFINED CMAKE_BUILD_TYPE AND NOT MSVC)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
+    message(STATUS "CMAKE_BUILD_TYPE not set, defaulting to Release")
+elseif(NOT MSVC)
+    message(STATUS "CMAKE_BUILD_TYPE is set to ${CMAKE_BUILD_TYPE}")
+endif()
+
+# 检查编译器是否支持 C++17, 支持的话， 启用相机模块.
+include(CheckCXXSourceCompiles)
+
+if(MSVC)
+    set(CMAKE_REQUIRED_FLAGS "/std:c++17")
+else()
+    set(CMAKE_REQUIRED_FLAGS "-std=c++17")
+endif()
+
+check_cxx_source_compiles("
+    #include <optional>
+    int main() { std::optional<int> o; return 0; }
+" COMPILER_SUPPORTS_CXX17)
+unset(CMAKE_REQUIRED_FLAGS)
+
+if(COMPILER_SUPPORTS_CXX17)
+    option(EGE_ENABLE_CPP17 "Enable C++ 17" ON)
+else()
+    set(EGE_ENABLE_CPP17 OFF CACHE BOOL "Enable C++ 17" FORCE)
+endif()
+
+message(STATUS "EGE enable C++ 17: ${EGE_ENABLE_CPP17}")
+
+if(EGE_ENABLE_CPP17)
+    # 将编译标准设置为 C++17, 仓库对外标准保持不变, 未引入额外的依赖.
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
 add_library(xege STATIC)
 
 target_include_directories(xege PUBLIC include)
@@ -145,6 +182,10 @@ if(USE_LIBPNG_AND_ZLIB)
     endif()
 else()
     message(FATAL_ERROR "EGE MUST BE COMPILED WITH LIBPNG AND ZLIB!")
+endif()
+
+if(EGE_ENABLE_CPP17)
+    target_compile_definitions(xege PRIVATE EGE_ENABLE_CPP17=1)
 endif()
 
 # 设置库文件名

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,3 +1,13 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(ege-demos)
+
+if(EGE_ENABLE_CPP17)
+    # 将编译标准设置为 C++17, 仓库对外标准保持不变, 未引入额外的依赖.
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
 
 file(
   GLOB DEMO_SRCS

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -20,7 +20,9 @@
 #endif
 
 #define EGE_GRAPH_LIB_BUILD
+#ifndef EGE_DEPRECATE
 #define EGE_DEPRECATE(function, msg)
+#endif
 
 #include "ege.h"
 #include "ege/types.h"

--- a/tasks.sh
+++ b/tasks.sh
@@ -46,7 +46,7 @@ if [[ -z "$CMAKE_CONFIG_DEFINE" ]]; then
 fi
 
 function MY_CMAKE_BUILD_DEFINE() {
-    echo "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ${CMAKE_CONFIG_DEFINE}"
+    echo "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ${CMAKE_CONFIG_DEFINE} -DCMAKE_POLICY_VERSION_MINIMUM=3.13"
 }
 
 if ! command -v grealpath && command -v realpath; then


### PR DESCRIPTION
rt.
其他改动:
1. 优化 tasks, 解决编译问题
2. 优化 vscode 下项目开发过程中的代码提示
3. 修正 `ege_head.h` 在某些编译器下的编译问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 增加了 CMake 选项以支持启用或禁用 C++17，并在启用时为相关目标设置编译定义。
  * demo 工程现在声明了项目名称，并要求 CMake 最低版本为 3.13。

* **改进**
  * 默认将 C 和 C++ 标准分别提升至 C17 和 C++17。
  * 自动检测并配置 C++17 支持，构建时会有状态提示。
  * 在构建脚本中强制设置 CMake 最低策略版本为 3.13。

* **修复**
  * 优化了宏定义，避免重复定义可能引发的警告或错误。
  * 任务配置文件的问题匹配器切换为更适合 MSVC 的类型，提升兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->