### PR TITLE
修改了 build_commands.bat 中有关 MinGW 的构建命令

### DIFF
--- a/build_commands.bat
+++ b/build_commands.bat
@@ -1,9 +1,10 @@
 :: 以下命令用于将各版本库文件方便地输出到 build\lib 中
 
-
 :: MinGW
-cmake -G "MinGW Makefiles" -S . -B build\MinGW -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY="%CD%\build\lib\MinGW" -DCMAKE_BUILD_TYPE=Release
+cmake -G "MinGW Makefiles" -S . -B build\MinGW -DCMAKE_BUILD_TYPE=Release
 cmake --build build\MinGW -j
+mkdir build\lib\MinGW
+copy /Y build\MinGW\libgraphics.a build\lib\MinGW\libgraphics.a
 
 :: Visual Studio 2008 32bit
 :: FIXME: UNTESTED


### PR DESCRIPTION
由于 libpng 里面用了 copy_if_different复制静态库，导致全局指定输出目录无法成功构建，故删去 -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY 参数，使用 copy 命令手动复制 libgraphics.a 到 build/lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 优化了 MinGW 构建脚本，调整静态库输出目录的处理方式，提升构建流程的清晰度和一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->