### PR TITLE
compat: 以支持C++新标准的高版本 TDM-GCC 编译器编译时，兼容 Dev-C++ 内置低版本编译器

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,6 +305,14 @@ if(MSVC)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     message(STATUS "GNU target: GCC ${CMAKE_C_COMPILER_VERSION}")
 
+    if (DEFINED EGE_CRT_COMPAT_DEVCPP)
+        message(STATUS "Using Dev-C++ compatibility mode.")
+        target_compile_definitions(xege PRIVATE
+            _GLIBCXX_USE_CXX11_ABI=0
+            EGE_CRT_COMPAT_DEVCPP=1
+        )
+    endif()
+
     if(CMAKE_HOST_UNIX)
         target_compile_definitions(xege PRIVATE _FORTIFY_SOURCE=0)
     endif()

--- a/src/crt_compat.cpp
+++ b/src/crt_compat.cpp
@@ -1,0 +1,31 @@
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+
+/* Dev-C++ (v5.11, TDM-GCC 4.9.2)兼容 */
+#ifdef EGE_CRT_COMPAT_DEVCPP
+#ifdef __GNUC__
+void operator delete(void* ptr, std::size_t size) noexcept
+{
+    operator delete(ptr);
+}
+
+void operator delete[](void* ptr, std::size_t size) noexcept
+{
+    operator delete[](ptr);
+}
+
+
+extern "C"
+{
+
+FILE* __cdecl __imp___acrt_iob_func(unsigned i)
+{
+    return &__iob_func()[i];
+}
+
+}
+
+#endif // __GNUC__
+#endif // EGE_CRT_COMPAT_DEVCPP
+


### PR DESCRIPTION
由于 Dev-C++  内置编译器版本过低，不支持 C++17 标准，因为如果代码需要以 C++17 进行编译，则需要用更高版本的 TDM-GCC 进行编译。然而低版本编译器链接由高版本编译器生成的库文件，会有符号未定义问题，这次修改即为解决此问题。

如果需要兼容，需在 CMake 构建时使用 -D 参数定义 EGE_CRT_COMPAT_DEVCPP 宏。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加了对 Dev-C++ 兼容模式的支持，可在特定环境下启用兼容性修复。
  * 新增了针对 Dev-C++ 的内存释放和标准 I/O 兼容性处理。

* **其他**
  * 构建配置中增加了相关条件判断和提示信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->