### PR TITLE
feat: 新增 INIT_EVENTLOOP 初始化模式，事件循环由主线程执行

### DIFF
--- a/demo/game_tetris.cpp
+++ b/demo/game_tetris.cpp
@@ -17,7 +17,7 @@ static int g_map_mod[] = {1, 4, 4, 4, 2, 2, 2, 1, 0};
 
 /* 初始化全局数据及图形显示 */
 void initgr() {
-    initgraph(g_width, g_height);
+    initgraph(g_width, g_height, INIT_RENDERMANUAL | INIT_EVENTLOOP);
     setfont(12, 6, "宋体");
     int Trs_map[8][4][4][4] =
     {
@@ -385,7 +385,7 @@ int main() {
     game.m_droptime = nfps / 2;
     game.m_movxtime = 10;
 
-    setrendermode(RENDER_MANUAL);
+    //setrendermode(RENDER_MANUAL);
     for ( ; is_run(); delay_fps(nfps)) {
         game.update();
         game.render();

--- a/demo/test_doubleclick.cpp
+++ b/demo/test_doubleclick.cpp
@@ -16,7 +16,7 @@ int mouseKeyToIndex(int keyMask)
 int main()
 {
     const int winWidth = 1200, winHeight = 300;
-    initgraph(winWidth, winHeight, INIT_RENDERMANUAL);
+    initgraph(winWidth, winHeight, INIT_RENDERMANUAL | INIT_EVENTLOOP);
     ege_enable_aa(true);
 
     setlinecolor(EGEARGB(128, 81, 128, 222));

--- a/include/ege.h
+++ b/include/ege.h
@@ -217,6 +217,8 @@ enum initmode_flag
     INIT_UNICODE         = 0x20,  ///< Unicode character messages (equivalent to setunicodecharmessage(true))
     INIT_HIDE            = 0x40,  ///< Hidden window
     INIT_WITHLOGO        = 0x100, ///< Show EGE Logo animation on startup (not shown by default in Debug version)
+    INIT_EVENTLOOP       = 0x200, ///< Event loop
+
     INIT_ANIMATION       = INIT_DEFAULT | INIT_RENDERMANUAL | INIT_NOFORCEEXIT ///< Animation mode
 };
 

--- a/src/ege_graph.h
+++ b/src/ege_graph.h
@@ -18,13 +18,19 @@ class egeControlBase;   // 前置声明
 
 initmode_flag getinitmode();
 
+int initWindow(_graph_setting* pg);
+
 void logoscene();
+
+int messageHandle();
 
 int dealmessage(_graph_setting* pg, bool force_update);
 
 bool needToUpdate(_graph_setting* pg);
 
 int graphupdate(_graph_setting* pg);
+
+int graphInitOption();
 
 void guiupdate(_graph_setting* pg, egeControlBase* root);
 

--- a/src/ege_head.h
+++ b/src/ege_head.h
@@ -193,6 +193,7 @@ struct _graph_setting
     std::wstring window_caption;
     HICON        window_hicon;
     color_t      window_initial_color;
+    int          init_option;
     int          exit_flag;
     int          exit_window;
     int          update_mark_count; // 更新标记

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -1450,8 +1450,13 @@ void setfillstyle(int pattern, color_t color, PIMAGE pimg)
 
 void setrendermode(rendermode_e mode)
 {
+    struct _graph_setting* pg = &graph_setting;
+    /* INIT_EVENTLOOP 模式下，固定为 RENDER_MANUAL 模式*/
+    if (pg->init_option & INIT_EVENTLOOP) {
+        return;
+    }
+
     if (mode == RENDER_MANUAL) {
-        struct _graph_setting* pg = &graph_setting;
         if (pg->lock_window) {
             ;
         } else {
@@ -1459,12 +1464,12 @@ void setrendermode(rendermode_e mode)
             pg->timer_stop_mark = true;
             PostMessageW(pg->hwnd, WM_TIMER, RENDER_TIMER_ID, 0);
             pg->lock_window = true;
+
             while (pg->timer_stop_mark) {
                 ::Sleep(1);
             }
         }
     } else {
-        struct _graph_setting* pg = &graph_setting;
         delay_ms(0);
         SetTimer(pg->hwnd, RENDER_TIMER_ID, 50, NULL);
         pg->skip_timer_mark = false;

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -129,6 +129,10 @@ void delay_fps(double fps)
         dw = pg->delay_fps_dwLast;
     }
 
+    if (pg->init_option & INIT_EVENTLOOP) {
+        messageHandle();
+    }
+
     root->draw(NULL);
 
     for (; nloop >= 0; --nloop) {


### PR DESCRIPTION
设置 INIT_EVENTLOOP 后，主线程成为 UI 线程，由主线程创建窗口和处理系统消息，和主流框架一致。设置此模式后，渲染模式将被固定设置为 RENDER_MANUAL ，不可调整。
用户需定时调用 delay_ms(), getch(), delay_fps()等函数以处理系统消息，不可间隔过长(阈值在5秒左右)，否则窗口将会被系统标记为无响应。