### PR TITLE
优化编译脚本， 极可能开启相机 feature, 默认检查 ccache 并开启,  方便编译加速

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,13 +93,7 @@ unset(CMAKE_REQUIRED_FLAGS)
 if(COMPILER_SUPPORTS_CXX17)
     option(EGE_ENABLE_CPP17 "Enable C++ 17" ON)
 
-    if(NOT EGE_NON_WINDOWS)
-        # 仅在 Windows 上启用相机捕获功能, 因为 Linux 以及 macOS 上基于 WINE 运行, 还无法启动相机设备.
     set(EGE_ENABLE_CAMERA_CAPTURE_DEFAULT ON)
-    else()
-        set(EGE_ENABLE_CAMERA_CAPTURE_DEFAULT OFF)
-    endif()
-
     option(EGE_ENABLE_CAMERA_CAPTURE "Enable camera capture" ${EGE_ENABLE_CAMERA_CAPTURE_DEFAULT})
     message(STATUS "EGE_ENABLE_CAMERA_CAPTURE: ${EGE_ENABLE_CAMERA_CAPTURE}")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,8 @@ if(CMAKE_HOST_UNIX)
     set(EGE_NON_WINDOWS ON CACHE BOOL "EGE is not compiled on Windows" FORCE)
 endif()
 
-# 检查并启用 ccache（当 EGE_IS_ROOT_PROJECT 为 ON 且不是 MSVC 时）
-if(EGE_IS_ROOT_PROJECT AND NOT MSVC)
+# 检查并启用 ccache（当 EGE_IS_ROOT_PROJECT 为 ON 且不是 Visual Studio generator 时）
+if(EGE_IS_ROOT_PROJECT AND NOT CMAKE_GENERATOR MATCHES "Visual Studio")
     find_program(CCACHE_FOUND ccache)
 
     if(CCACHE_FOUND)


### PR DESCRIPTION
- 只要编译器支持 c++17, 就启用 ccap, 减少代码分歧. 这样使用 ubuntu/macOS 编译出来的产物, 拿回 Windows 上也能具备相机相关功能
- 优化对于 ccache 的启用逻辑, 正确屏蔽 visual studio (不生效), 其他情况下可用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **优化**
  * 改进了对 Visual Studio 生成器的兼容性处理，调整了 ccache 启用条件。
  * 相机捕获功能现默认在所有平台上启用，无论操作系统类型。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->