### PR TITLE
compat: 兼容低版本编译器以使用 stdint.h 中的宏

### DIFF
--- a/include/ege.h
+++ b/include/ege.h
@@ -71,6 +71,14 @@
 #endif
 #endif
 
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+
+#ifndef __STDC_CONSTANT_MACROS
+#define __STDC_CONSTANT_MACROS
+#endif
+
 #include "ege/stdint.h"
 
 #if defined(EGE_FOR_AUTO_CODE_COMPLETETION_ONLY)

--- a/include/ege/stdint.h
+++ b/include/ege/stdint.h
@@ -48,7 +48,7 @@
 #else
 
 /* Avoid duplication with definitions in other stdint.h header files */
-#if !definded(_STDINT) && !defined(_GCC_STDINT_H)
+#if !defined(_STDINT) && !defined(_GCC_STDINT_H)
 #if defined(_MSC_VER)
 #define _STDINT
 #elif defined(__GNUC__)


### PR DESCRIPTION
INT32_MIN, INT32_MAX 等宏为常用宏，在 GCC 中，如果标准低于 C++11, stdint.h  默认不启用这些宏。这里启用这些宏以便于使用。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复**
  * 修正了预处理指令中的拼写错误，提升了条件编译的准确性。

* **其他**
  * 优化了对标准整数宏的支持，增强了与 C++ 标准头文件的兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->