### PR TITLE
compat: 解决 VS2017 下未找到  _BitScanReverse  标识符的问题

### DIFF
--- a/src/sdefl_impl.cpp
+++ b/src/sdefl_impl.cpp
@@ -1,9 +1,7 @@
-//
-// Created by 19078 on 2025/8/14.
-//
-
-#ifndef SDEFL_IMPLEMENTATION
-#define SDEFL_IMPLEMENTATION
+#ifdef _MSC_VER
+#include <intrin.h>
 #endif
+
+#define SDEFL_IMPLEMENTATION
 
 #include "external/sdefl.h"

--- a/src/sinfl_impl.cpp
+++ b/src/sinfl_impl.cpp
@@ -1,5 +1,7 @@
-#ifndef SINFL_IMPLEMENTATION
-#define SINFL_IMPLEMENTATION
+#ifdef _MSC_VER
+#include <intrin.h>
 #endif
+
+#define SINFL_IMPLEMENTATION
 
 #include "external/sinfl.h"


### PR DESCRIPTION
MSVC 中的_BitScanReverse 需要头文件 <intrin.h>，这个头文件在 VS2019及以上版本中被库中引入其它头文件所包含，然而 VS 之前的版本包含关系不同，这里显示包含头文件