### PR TITLE
adjust: 图像像素颜色格式由 ARGB32 改为 PRGB32

### DIFF
--- a/include/ege.h
+++ b/include/ege.h
@@ -332,8 +332,21 @@ typedef uint32_t color_t;
  */
 enum alpha_type
 {
-    ALPHATYPE_STRAIGHT      = 0,    ///< Straight alpha (non-premultiplied alpha)
-    ALPHATYPE_PREMULTIPLIED = 1     ///< Premultiplied alpha
+    ALPHATYPE_PREMULTIPLIED = 0,    ///< Premultiplied alpha
+    ALPHATYPE_STRAIGHT      = 1     ///< Straight alpha (non-premultiplied alpha)
+};
+
+/**
+ * @enum color_type
+ * @brief Color types
+ *
+ * Defines the color type of the pixel
+ */
+enum color_type
+{
+    COLORTYPE_PRGB32 = 0,   ///< RGB color with premultiplied alpha channel. (32-bit, 8-bit per channel)
+    COLORTYPE_ARGB32 = 1,   ///< RGB color with alpha channel. (32-bit, 8-bit per channel)
+    COLORTYPE_RGB32  = 2    ///< RGB color. (32-bit, 8-bit per channel, alpha channel is ignored and forced to be opaque)
 };
 
 /**
@@ -4443,7 +4456,7 @@ int EGEAPI putimage_transparent(
  * @param xDest X coordinate of drawing position
  * @param yDest Y coordinate of drawing position
  * @param alpha Overall image transparency (0-255), 0 is completely transparent, 255 is completely opaque
- * @param alphaType Alpha type of source image pixels, default is ALPHATYPE_STRAIGHT
+ * @param colorType Color type of source image pixels, default is COLORTYPE_PRGB32
  * @return Returns grOk on success, corresponding error code on failure
  */
 int EGEAPI putimage_alphablend(
@@ -4452,7 +4465,7 @@ int EGEAPI putimage_alphablend(
     int xDest,
     int yDest,
     unsigned char alpha,
-    alpha_type alphaType = ALPHATYPE_STRAIGHT
+    color_type colorType = COLORTYPE_PRGB32
 );
 
 /**
@@ -4464,7 +4477,7 @@ int EGEAPI putimage_alphablend(
  * @param alpha Overall image transparency (0-255), 0 is completely transparent, 255 is completely opaque
  * @param xSrc X coordinate of top-left corner of drawing content in source IMAGE object
  * @param ySrc Y coordinate of top-left corner of drawing content in source IMAGE object
- * @param alphaType Alpha type of source image pixels, default is ALPHATYPE_STRAIGHT
+ * @param colorType Color type of source image pixels, default is COLORTYPE_PRGB32
  * @return Returns grOk on success, corresponding error code on failure
  */
 int EGEAPI putimage_alphablend(
@@ -4475,7 +4488,7 @@ int EGEAPI putimage_alphablend(
     unsigned char alpha,
     int xSrc,
     int ySrc,
-    alpha_type alphaType = ALPHATYPE_STRAIGHT
+    color_type colorType = COLORTYPE_PRGB32
 );
 
 /**
@@ -4489,7 +4502,7 @@ int EGEAPI putimage_alphablend(
  * @param ySrc Y coordinate of top-left corner of drawing content in source IMAGE object
  * @param widthSrc Width of drawing content in source IMAGE object
  * @param heightSrc Height of drawing content in source IMAGE object
- * @param alphaType Alpha type of source image pixels, default is ALPHATYPE_STRAIGHT
+ * @param colorType Color type of source image pixels, default is COLORTYPE_PRGB32
  * @return Returns grOk on success, corresponding error code on failure
  */
 int EGEAPI putimage_alphablend(
@@ -4502,7 +4515,7 @@ int EGEAPI putimage_alphablend(
     int ySrc,
     int widthSrc,
     int heightSrc,
-    alpha_type alphaType = ALPHATYPE_STRAIGHT
+    color_type colorType = COLORTYPE_PRGB32
 );
 
 /**
@@ -4519,7 +4532,7 @@ int EGEAPI putimage_alphablend(
  * @param widthSrc Width of drawing content in source IMAGE object
  * @param heightSrc Height of drawing content in source IMAGE object
  * @param smooth Whether to use smooth processing (anti-aliasing), default is false
- * @param alphaType Alpha type of source image pixels, default is ALPHATYPE_STRAIGHT
+ * @param colorType Color type of source image pixels, default is COLORTYPE_PRGB32
  * @return Returns grOk on success, corresponding error code on failure
  */
 int EGEAPI putimage_alphablend(
@@ -4535,7 +4548,7 @@ int EGEAPI putimage_alphablend(
     int widthSrc,
     int heightSrc,
     bool smooth = false,
-    alpha_type alphaType = ALPHATYPE_STRAIGHT
+    color_type colorType = COLORTYPE_PRGB32
 );
 
 /**

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -374,7 +374,7 @@ color_t alphablend(color_t dst, color_t src, unsigned char srcAlphaFactor)
 
 color_t alphablend_premultiplied(color_t dst, color_t src)
 {
-    return alphablend_premultiplied_inline(dst, src);
+    return alphablend_premul_inline(dst, src);
 }
 
 color_t alphablend_premultiplied(color_t dst, color_t src, unsigned char srcAlphaFactor)
@@ -384,7 +384,7 @@ color_t alphablend_premultiplied(color_t dst, color_t src, unsigned char srcAlph
     byte green = DIVIDE_255_FAST(EGEGET_G(src) * srcAlphaFactor + 255/2);
     byte blue  = DIVIDE_255_FAST(EGEGET_B(src) * srcAlphaFactor + 255/2);
 
-    return alphablend_premultiplied_inline(dst, EGEARGB(alpha, red, green, blue));
+    return alphablend_premul_inline(dst, EGEARGB(alpha, red, green, blue));
 }
 
 void ARGBToABGR(color_t* dst, const color_t* src, int count)

--- a/src/egegapi.cpp
+++ b/src/egegapi.cpp
@@ -2157,7 +2157,7 @@ void EGEAPI ege_drawimage(PCIMAGE srcimg, int xDest, int yDest, PIMAGE pimg)
         Gdiplus::Bitmap bitmap(srcimg->getwidth(),
             srcimg->getheight(),
             4 * srcimg->getwidth(),
-            PixelFormat32bppARGB,
+            PixelFormat32bppPARGB,
             (BYTE*)(srcimg->m_pBuffer));
         Gdiplus::Point p(xDest, yDest);
         graphics->DrawImage(&bitmap, p);
@@ -2182,7 +2182,7 @@ void EGEAPI ege_drawimage(PCIMAGE srcimg,
         Gdiplus::Bitmap bitmap(srcimg->getwidth(),
             srcimg->getheight(),
             4 * srcimg->getwidth(),
-            PixelFormat32bppARGB,
+            PixelFormat32bppPARGB,
             (BYTE*)(srcimg->m_pBuffer));
         Gdiplus::Point destPoints[3] = {
             Gdiplus::Point(xDest, yDest), Gdiplus::Point(xDest + widthDest, yDest), Gdiplus::Point(xDest, yDest + heightDest)};

--- a/src/image.h
+++ b/src/image.h
@@ -203,7 +203,7 @@ public:
         int                        ySrc = 0,                // y-coord of source upper-left corner
         int                        widthSrc   = 0,          // width of source rectangle
         int                        heightSrc  = 0,          // height of source rectangle
-        alpha_type                 alphaType  = ALPHATYPE_STRAIGHT  // alpha mode(straight alpha or premultiplied alpha)
+        color_type                 colorType  = COLORTYPE_PRGB32  // alpha mode(straight alpha or premultiplied alpha)
     ) const;
 
     int putimage_alphablend(PIMAGE imgDest,                 // handle to dest
@@ -217,7 +217,7 @@ public:
         int                        widthSrc,                // width of source rectangle
         int                        heightSrc,               // height of source rectangle
         bool                       smooth = false,
-        alpha_type                 alphaType  = ALPHATYPE_STRAIGHT  // alpha mode(straight alpha or premultiplied alpha)
+        color_type                 colorType  = COLORTYPE_PRGB32  // alpha mode(straight alpha or premultiplied alpha)
     ) const;
 
     int putimage_alphatransparent(PIMAGE imgDest,           // handle to dest
@@ -310,6 +310,26 @@ public:
 graphics_errors getimage_from_bitmap(PIMAGE pimg, Gdiplus::Bitmap& bitmap);
 
 int savebmp(PCIMAGE pimg, FILE* file, bool alpha = false);
+
+int image_premultiply(PIMAGE pimg);
+
+int image_premultiply(color_t* pixels, int width, int height);
+
+int image_premultiply(color_t* dst, const color_t* src, int width, int height);
+
+// 图像做预乘 alpha 处理，像素颜色由 (a, R, G, B) 转换为 (a, a*R, a*G, a*B) (这里 a 归一化为 0.0~1.0)
+// dstStride 和 srcStride 是以像素为单位
+int image_premultiply(color_t* dst, const color_t* src, int width, int height, int dstStride, int srcStride);
+
+int image_unpremultiply(PIMAGE pimg);
+
+int image_unpremultiply(color_t* pixels, int width, int height);
+
+int image_unpremultiply(color_t* dst, const color_t* src, int width, int height);
+
+// 图像去预乘 alpha 处理，像素颜色由 (a, a*R, a*G, a*B) 转换为 (a, R, G, B) (这里 a 归一化为 0.0~1.0)
+// dstStride 和 srcStride 是以像素为单位
+int image_unpremultiply(color_t* dst, const color_t* src, int width, int height, int dstStride, int srcStride);
 
 ImageFormat checkImageFormatByFileName(const wchar_t* fileName);
 

--- a/tests/tests/putimage_alphablend_test.cpp
+++ b/tests/tests/putimage_alphablend_test.cpp
@@ -2,8 +2,8 @@
  * putimage_alphablend 透明混合性能测试
  *
  * 测试不同版本的 putimage_alphablend 函数，以及它们对应的不同代码路径：
- * 1. 软件 alphablend_inline 实现（ALPHATYPE_STRAIGHT）
- * 2. Windows AlphaBlend API 实现（ALPHATYPE_PREMULTIPLIED）
+ * 1. 软件 alphablend_inline 实现（COLORTYPE_ARGB32）
+ * 2. Windows AlphaBlend API 实现（COLORTYPE_PRGB32）
  * 3. GDI+ 实现（缩放和平滑处理）
  */
 
@@ -72,7 +72,7 @@ int main() {
         std::vector<int> alphaValues = { 64, 128, 192, 255 };
         for (int alpha : alphaValues) {
             std::string testName = "Alpha=" + std::to_string(alpha) + " (基础版本)";
-            testFunction(testName, [&]() { ege::putimage_alphablend(nullptr, srcImg, 0, 0, (unsigned char)alpha, ALPHATYPE_STRAIGHT); });
+            testFunction(testName, [&]() { ege::putimage_alphablend(nullptr, srcImg, 0, 0, (unsigned char)alpha, COLORTYPE_ARGB32); });
         }
 
         // 测试不同的函数版本（避免重复的实现）
@@ -82,15 +82,15 @@ int main() {
         unsigned char testAlpha = 128;
 
         // 版本1：基础版本 - 只有位置
-        testFunction("版本1: 只有位置参数", [&]() { ege::putimage_alphablend(nullptr, srcImg, 10, 10, testAlpha, ALPHATYPE_STRAIGHT); });
+        testFunction("版本1: 只有位置参数", [&]() { ege::putimage_alphablend(nullptr, srcImg, 10, 10, testAlpha, COLORTYPE_ARGB32); });
 
         // 版本2：指定源起始位置
         testFunction("版本2: 指定源位置",
-                     [&]() { ege::putimage_alphablend(nullptr, srcImg, 10, 10, testAlpha, 0, 0, ALPHATYPE_STRAIGHT); });
+                     [&]() { ege::putimage_alphablend(nullptr, srcImg, 10, 10, testAlpha, 0, 0, COLORTYPE_ARGB32); });
 
         // 版本3：指定源矩形
         testFunction("版本3: 指定源矩形", [&]() {
-            ege::putimage_alphablend(nullptr, srcImg, 10, 10, testAlpha, 0, 0, res.width / 2, res.height / 2, ALPHATYPE_STRAIGHT);
+            ege::putimage_alphablend(nullptr, srcImg, 10, 10, testAlpha, 0, 0, res.width / 2, res.height / 2, COLORTYPE_ARGB32);
         });
 
         // 测试核心实现路径差异
@@ -99,17 +99,17 @@ int main() {
 
         // 路径1：软件实现 - alpha=255（优化路径）
         testFunction("软件实现 alpha=255", [&]() {
-            ege::putimage_alphablend(nullptr, srcImg, 10, 10, (unsigned char)255, 0, 0, res.width / 2, res.height / 2, ALPHATYPE_STRAIGHT);
+            ege::putimage_alphablend(nullptr, srcImg, 10, 10, (unsigned char)255, 0, 0, res.width / 2, res.height / 2, COLORTYPE_ARGB32);
         });
 
         // 路径2：软件实现 - alpha<255
         testFunction("软件实现 alpha<255", [&]() {
-            ege::putimage_alphablend(nullptr, srcImg, 10, 10, testAlpha, 0, 0, res.width / 2, res.height / 2, ALPHATYPE_STRAIGHT);
+            ege::putimage_alphablend(nullptr, srcImg, 10, 10, testAlpha, 0, 0, res.width / 2, res.height / 2, COLORTYPE_ARGB32);
         });
 
         // 路径3：Windows AlphaBlend API
         testFunction("Windows AlphaBlend API", [&]() {
-            ege::putimage_alphablend(nullptr, srcImg, 10, 10, testAlpha, 0, 0, res.width / 2, res.height / 2, ALPHATYPE_PREMULTIPLIED);
+            ege::putimage_alphablend(nullptr, srcImg, 10, 10, testAlpha, 0, 0, res.width / 2, res.height / 2, COLORTYPE_PRGB32);
         });
 
         // 测试高级版本（缩放和平滑）
@@ -119,25 +119,25 @@ int main() {
         // 无缩放 - 基础GDI+路径
         testFunction("GDI+ 无缩放", [&]() {
             ege::putimage_alphablend(nullptr, srcImg, 10, 10, res.width / 2, res.height / 2, testAlpha, 0, 0, res.width / 2, res.height / 2,
-                                     false, ALPHATYPE_STRAIGHT);
+                                     false, COLORTYPE_ARGB32);
         });
 
         // 缩放 - GDI+缩放
         testFunction("GDI+ 2x缩放", [&]() {
             ege::putimage_alphablend(nullptr, smallSrcImg, 10, 10, res.width / 2, res.height / 2, testAlpha, 0, 0, res.width / 4,
-                                     res.height / 4, false, ALPHATYPE_STRAIGHT);
+                                     res.height / 4, false, COLORTYPE_ARGB32);
         });
 
         // 平滑缩放
         testFunction("GDI+ 2x缩放+平滑", [&]() {
             ege::putimage_alphablend(nullptr, smallSrcImg, 10, 10, res.width / 2, res.height / 2, testAlpha, 0, 0, res.width / 4,
-                                     res.height / 4, true, ALPHATYPE_STRAIGHT);
+                                     res.height / 4, true, COLORTYPE_ARGB32);
         });
 
         // 预乘Alpha + 平滑（强制使用GDI+）
         testFunction("GDI+ 预乘Alpha+平滑", [&]() {
             ege::putimage_alphablend(nullptr, srcImg, 10, 10, res.width / 2, res.height / 2, testAlpha, 0, 0, res.width / 2, res.height / 2,
-                                     true, ALPHATYPE_PREMULTIPLIED);
+                                     true, COLORTYPE_PRGB32);
         });
 
         // 测试极端情况
@@ -146,15 +146,15 @@ int main() {
 
         // Alpha=0（应该直接返回）
         testFunction("Alpha=0 (直接返回)",
-                     [&]() { ege::putimage_alphablend(nullptr, srcImg, 10, 10, (unsigned char)0, ALPHATYPE_STRAIGHT); });
+                     [&]() { ege::putimage_alphablend(nullptr, srcImg, 10, 10, (unsigned char)0, COLORTYPE_ARGB32); });
 
         // 小矩形复制
         testFunction("小矩形 (100x100)",
-                     [&]() { ege::putimage_alphablend(nullptr, srcImg, 10, 10, testAlpha, 0, 0, 100, 100, ALPHATYPE_STRAIGHT); });
+                     [&]() { ege::putimage_alphablend(nullptr, srcImg, 10, 10, testAlpha, 0, 0, 100, 100, COLORTYPE_ARGB32); });
 
         // 大矩形复制
         testFunction("大矩形 (整个图像)", [&]() {
-            ege::putimage_alphablend(nullptr, srcImg, 0, 0, testAlpha, 0, 0, res.width, res.height, ALPHATYPE_STRAIGHT);
+            ege::putimage_alphablend(nullptr, srcImg, 0, 0, testAlpha, 0, 0, res.width, res.height, COLORTYPE_ARGB32);
         });
 
         // 性能总结
@@ -168,7 +168,7 @@ int main() {
             "多次小图像绘制 (10次)",
             [&]() {
                 for (int i = 0; i < 10; i++) {
-                    ege::putimage_alphablend(nullptr, smallSrcImg, i * 50, i * 40, testAlpha, ALPHATYPE_STRAIGHT);
+                    ege::putimage_alphablend(nullptr, smallSrcImg, i * 50, i * 40, testAlpha, COLORTYPE_ARGB32);
                 }
             },
             batchIterations);
@@ -178,7 +178,7 @@ int main() {
             "多次大图像绘制 (10次)",
             [&]() {
                 for (int i = 0; i < 10; i++) {
-                    ege::putimage_alphablend(nullptr, srcImg, (i % 3) * 100, (i % 3) * 100, testAlpha, ALPHATYPE_STRAIGHT);
+                    ege::putimage_alphablend(nullptr, srcImg, (i % 3) * 100, (i % 3) * 100, testAlpha, COLORTYPE_ARGB32);
                 }
             },
             batchIterations);


### PR DESCRIPTION
图像像素颜色类型由 ARGB32 (带 alpha 通道的 RGB 格式)改为 PRGB32 (预乘 alpha 的 RGB 格式)。
* PRGB32 格式为 Alpha Blend 算法所生成的颜色格式，甚至部分图形库只使用 PRGB 和不支持 ARGB 格式，统一使用 PRGB32 有利于改善和其它图形库的接口兼容性问题。
* 由于 Alpha Blend 算法生成的颜色格式默认为 PRGB 格式，所以如果带透明通道的绘图结果需要再次绘制到其它图像上，需要进行一次格式转换才能使用 ARGB 格式的接口。改为 PRGB 格式后不需要再进行格式转换操作，可稍微提升性能。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alpha-blend calls now accept explicit color-type selection (premultiplied, straight/ARGB, or opaque) and default to premultiplied.
  * New public premultiply/unpremultiply utilities and optimized unpremultiply table for image buffers.
* **Refactor**
  * Default handling moved to premultiplied alpha; alpha-type parameter replaced by color-type across APIs.
* **Documentation**
  * Updated docs and examples to use color-type terminology and premultiplied semantics.
* **Tests**
  * Test suites updated to use COLORTYPE_* enums across alpha-blend scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->