### PR TITLE
feat: 增加 image_convertcolor 函数用于转换图像的颜色类型

### DIFF
--- a/include/ege.h
+++ b/include/ege.h
@@ -1810,6 +1810,20 @@ color_t EGEAPI alphablend_premultiplied(color_t dst, color_t src);
 color_t EGEAPI alphablend_premultiplied(color_t dst, color_t src, unsigned char srcAlphaFactor);
 
 /**
+ * @brief Convert pixel color types of the image，convert from src color type to dst color type.
+* @details
+* - src == dst, do nothing.
+* - RGB32  --> ARGB32, RGB32 --> PRGB32, ARGB32 --> RGB32: set alpha to 0xFF
+* - ARGB32 --> PRGB32: premultiply alpha
+* - PRGB32 --> ARGB32: unpremultiply alpha
+* - PRGB32 -->  RGB32: unpremultiply alpha and then set alpha to 0xFF
+ * @param pimg image
+ * @param src Source color type
+ * @param dst Destingnation color type
+ */
+void EGEAPI image_convertcolor(PIMAGE pimg, color_type src, color_type dst);
+
+/**
  * @brief Get pixel color
  * @param x X coordinate
  * @param y Y coordinate

--- a/src/image.h
+++ b/src/image.h
@@ -321,15 +321,16 @@ int image_premultiply(color_t* dst, const color_t* src, int width, int height);
 // dstStride 和 srcStride 是以像素为单位
 int image_premultiply(color_t* dst, const color_t* src, int width, int height, int dstStride, int srcStride);
 
-int image_unpremultiply(PIMAGE pimg);
+int image_unpremultiply(PIMAGE pimg, bool opaque = false);
 
-int image_unpremultiply(color_t* pixels, int width, int height);
+int image_unpremultiply(color_t* pixels, int width, int height, bool opaque = false);
 
-int image_unpremultiply(color_t* dst, const color_t* src, int width, int height);
+int image_unpremultiply(color_t* dst, const color_t* src, int width, int height, bool opaque = false);
 
-// 图像去预乘 alpha 处理，像素颜色由 (a, a*R, a*G, a*B) 转换为 (a, R, G, B) (这里 a 归一化为 0.0~1.0)
+// 图像的 RGB 去预乘 alpha 处理，像素颜色由 (a, a*R, a*G, a*B) 转换为 (a, R, G, B) (这里 a 归一化为 0.0~1.0)
 // dstStride 和 srcStride 是以像素为单位
-int image_unpremultiply(color_t* dst, const color_t* src, int width, int height, int dstStride, int srcStride);
+// 如果 opaque 为 true，RGB 通道去预乘 alpha 后还会将 alpha通道设置为 0xFF
+int image_unpremultiply(color_t* dst, const color_t* src, int width, int height, int dstStride, int srcStride, bool opaque = false);
 
 ImageFormat checkImageFormatByFileName(const wchar_t* fileName);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a color-format conversion capability between RGB/ARGB/PRGB with automatic alpha handling and no-op when formats match.
  * Adds an option to force fully opaque alpha during conversions/unpremultiply operations, improving predictable results for opaque image outputs and downstream blending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->