### PR TITLE
process cannot exit

### DIFF
--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -99,7 +99,7 @@ unsigned long getlogodatasize();
 }
 #endif
 
-DWORD WINAPI messageloopthread(LPVOID lpParameter);
+DWORD WINAPI messageloopthread(_graph_setting* pg);
 
 _graph_setting::_graph_setting() : init_sem{0}
 {
@@ -621,6 +621,7 @@ static LRESULT CALLBACK wndproc(HWND hWnd, UINT message, WPARAM wParam, LPARAM l
         if (pg == pg_w) {
             if (pg->callback_close) {
                 pg->callback_close();
+                return DefWindowProcW(hWnd, message, wParam, lParam);
             } else {
                 return DefWindowProcW(hWnd, message, wParam, lParam);
             }
@@ -952,11 +953,8 @@ void closegraph()
 }
 
 /*private function*/
-DWORD WINAPI messageloopthread(LPVOID lpParameter)
+DWORD WINAPI messageloopthread(_graph_setting* pg)
 {
-    _graph_setting* pg = (_graph_setting*)lpParameter;
-    MSG             msg;
-
     /* 执行应用程序初始化: */
     if (!init_instance(pg->instance)) {
         return 0xFFFFFFFF;
@@ -981,6 +979,7 @@ DWORD WINAPI messageloopthread(LPVOID lpParameter)
 
     pg->init_sem.add_permit();
 
+    MSG msg;
     while (!pg->exit_window) {
         if (GetMessageW(&msg, NULL, 0, 0)) {
             TranslateMessage(&msg);

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -621,10 +621,8 @@ static LRESULT CALLBACK wndproc(HWND hWnd, UINT message, WPARAM wParam, LPARAM l
         if (pg == pg_w) {
             if (pg->callback_close) {
                 pg->callback_close();
-                return DefWindowProcW(hWnd, message, wParam, lParam);
-            } else {
-                return DefWindowProcW(hWnd, message, wParam, lParam);
             }
+            return DefWindowProcW(hWnd, message, wParam, lParam);
         }
         break;
     case WM_DESTROY:
@@ -957,6 +955,7 @@ DWORD WINAPI messageloopthread(_graph_setting* pg)
 {
     /* 执行应用程序初始化: */
     if (!init_instance(pg->instance)) {
+        pg->init_sem.add_permit();
         return 0xFFFFFFFF;
     }
 


### PR DESCRIPTION
进程在窗口关闭后由于关闭事件实际上没有成功分发，导致进程无法退出。

这是我引入 std::thread 并在 _graph_setting 析构时 join thread 暴露出来的问题，之前可能进程都是异常退出的。

顺便把 messageloopthread 这个没有必要的 LPVOID 参数直接改成 _graph_setting *

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化窗口关闭流程，提升关闭响应的一致性。
  * 改进图形后台处理流程，增强运行稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->