### PR TITLE
Add software-rendered Cube Runner demo

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -351,6 +351,24 @@
             "options": {"cwd": "${workspaceFolder}"},
             "group": "build",
             "problemMatcher": "$gcc"
+        },
+        {
+            "label": "Run Demo - Cube Runner (Debug)",
+            "type": "shell",
+            "command": "bash",
+            "args": ["-l", "tasks.sh", "--debug", "--target", "game_cube_runner", "--build", "--run", "game_cube_runner.exe"],
+            "options": {"cwd": "${workspaceFolder}"},
+            "group": "build",
+            "problemMatcher": "$gcc"
+        },
+        {
+            "label": "Run Demo - Cube Runner (Release)",
+            "type": "shell",
+            "command": "bash",
+            "args": ["-l", "tasks.sh", "--release", "--target", "game_cube_runner", "--build", "--run", "game_cube_runner.exe"],
+            "options": {"cwd": "${workspaceFolder}"},
+            "group": "build",
+            "problemMatcher": "$gcc"
         }
     ]
 }

--- a/demo/game_cube_runner.cpp
+++ b/demo/game_cube_runner.cpp
@@ -3,20 +3,15 @@
 // Inspired by https://www.game5.com.de/cuberunner/index.html. The geometry,
 // rasterizer, HUD, and game logic below are original and use no external assets.
 
-#ifndef CUBE_RUNNER_HEADLESS
 #include <graphics.h>
-#endif
 
 #include <algorithm>
 #include <array>
-#include <chrono>
 #include <cmath>
 #include <condition_variable>
 #include <cstdint>
 #include <cstdlib>
-#include <fstream>
 #include <functional>
-#include <iomanip>
 #include <iostream>
 #include <limits>
 #include <mutex>
@@ -31,9 +26,7 @@
 
 // 文本本地化宏定义
 // 与其它 demo 一致: MSVC 编译器使用中文文案, 其它编译器使用英文文案.
-// 无头模式 (CUBE_RUNNER_HEADLESS) 始终使用英文, 因为内置位图字体仅支持 ASCII,
-// 且无头模式不依赖 EGE 字体系统.
-#if defined(_MSC_VER) && !defined(CUBE_RUNNER_HEADLESS)
+#ifdef _MSC_VER
 // MSVC 编译器使用中文文案
 #define TEXT_WINDOW_TITLE   "XEGE - 立方体跑酷"
 #define TEXT_HUD_TITLE      "立方体跑酷"
@@ -48,7 +41,7 @@
 #define TEXT_ACTION_RESUME  "[P] 继续"
 #define TEXT_FONT_NAME      "宋体"
 #else
-// 非MSVC编译器 (或无头模式) 使用英文文案
+// 非MSVC编译器使用英文文案
 #define TEXT_WINDOW_TITLE   "XEGE - Cube Runner"
 #define TEXT_HUD_TITLE      "CUBE RUNNER"
 #define TEXT_SCORE          "SCORE "
@@ -301,10 +294,13 @@ std::uint32_t packColor(Color color)
 
 class Surface {
 public:
-    explicit Surface(int width = kDefaultWidth, int height = kDefaultHeight)
+    // Borrows an externally-owned color buffer (typically the EGE PIMAGE buffer
+    // returned by getbuffer(); color_t is uint32_t and packColor already emits
+    // 0xAARRGGBB, so no conversion is needed). The z-buffer remains owned.
+    Surface(int width, int height, std::uint32_t* pixels)
         : width(width),
           height(height),
-          pixels(static_cast<std::size_t>(width) * height),
+          pixels(pixels),
           depth(static_cast<std::size_t>(width) * height)
     {
     }
@@ -315,7 +311,7 @@ public:
         const int bottom = std::clamp(gRenderBandBottom, top, height);
         const std::size_t first = static_cast<std::size_t>(top) * width;
         const std::size_t last = static_cast<std::size_t>(bottom) * width;
-        std::fill(pixels.begin() + first, pixels.begin() + last, packColor(color));
+        std::fill(pixels + first, pixels + last, packColor(color));
         std::fill(depth.begin() + first, depth.begin() + last,
             std::numeric_limits<float>::infinity());
     }
@@ -351,10 +347,10 @@ public:
         }
     }
 
-    int                        width;
-    int                        height;
-    std::vector<std::uint32_t> pixels;
-    std::vector<float>         depth;
+    int                width;
+    int                height;
+    std::uint32_t*     pixels;
+    std::vector<float> depth;
 };
 
 struct Projected {
@@ -530,136 +526,31 @@ Vec3 curveCenter(float z)
     return {0.0f, -(distance * distance) / 20.0f, z};
 }
 
-std::array<std::uint8_t, 7> glyph(char character)
+// HUD text helpers wrapping EGE's native font API, so the HUD can render CJK
+// (宋体 under MSVC) as well as ASCII. The font height tracks the old 5x7 bitmap
+// font's row count to preserve the original HUD layout.
+int textFontHeight(int scale)
 {
-    switch (character) {
-    case 'A': return {14, 17, 17, 31, 17, 17, 17};
-    case 'B': return {30, 17, 17, 30, 17, 17, 30};
-    case 'C': return {14, 17, 16, 16, 16, 17, 14};
-    case 'D': return {30, 17, 17, 17, 17, 17, 30};
-    case 'E': return {31, 16, 16, 30, 16, 16, 31};
-    case 'F': return {31, 16, 16, 30, 16, 16, 16};
-    case 'G': return {14, 17, 16, 23, 17, 17, 15};
-    case 'H': return {17, 17, 17, 31, 17, 17, 17};
-    case 'I': return {14, 4, 4, 4, 4, 4, 14};
-    case 'J': return {1, 1, 1, 1, 17, 17, 14};
-    case 'K': return {17, 18, 20, 24, 20, 18, 17};
-    case 'L': return {16, 16, 16, 16, 16, 16, 31};
-    case 'M': return {17, 27, 21, 21, 17, 17, 17};
-    case 'N': return {17, 25, 21, 19, 17, 17, 17};
-    case 'O': return {14, 17, 17, 17, 17, 17, 14};
-    case 'P': return {30, 17, 17, 30, 16, 16, 16};
-    case 'Q': return {14, 17, 17, 17, 21, 18, 13};
-    case 'R': return {30, 17, 17, 30, 20, 18, 17};
-    case 'S': return {15, 16, 16, 14, 1, 1, 30};
-    case 'T': return {31, 4, 4, 4, 4, 4, 4};
-    case 'U': return {17, 17, 17, 17, 17, 17, 14};
-    case 'V': return {17, 17, 17, 17, 17, 10, 4};
-    case 'W': return {17, 17, 17, 21, 21, 21, 10};
-    case 'X': return {17, 17, 10, 4, 10, 17, 17};
-    case 'Y': return {17, 17, 10, 4, 4, 4, 4};
-    case 'Z': return {31, 1, 2, 4, 8, 16, 31};
-    case '0': return {14, 17, 19, 21, 25, 17, 14};
-    case '1': return {4, 12, 4, 4, 4, 4, 14};
-    case '2': return {14, 17, 1, 2, 4, 8, 31};
-    case '3': return {30, 1, 1, 14, 1, 1, 30};
-    case '4': return {2, 6, 10, 18, 31, 2, 2};
-    case '5': return {31, 16, 16, 30, 1, 1, 30};
-    case '6': return {14, 16, 16, 30, 17, 17, 14};
-    case '7': return {31, 1, 2, 4, 8, 8, 8};
-    case '8': return {14, 17, 17, 14, 17, 17, 14};
-    case '9': return {14, 17, 17, 15, 1, 1, 14};
-    case '-': return {0, 0, 0, 31, 0, 0, 0};
-    case '/': return {1, 1, 2, 4, 8, 16, 16};
-    case '[': return {14, 8, 8, 8, 8, 8, 14};
-    case ']': return {14, 2, 2, 2, 2, 2, 14};
-    case ':': return {0, 4, 4, 0, 4, 4, 0};
-    default:  return {0, 0, 0, 0, 0, 0, 0};
-    }
+    return std::max(7, 7 * scale);
 }
 
-void drawText(Surface& surface, int x, int y, const std::string& text, int scale, Color color,
-    bool shadow = true)
+void drawTextLine(int x, int y, const std::string& text, int scale, Color color, bool shadow = true)
 {
-    auto drawGlyph = [&](int glyphX, int glyphY, char character, Color glyphColor) {
-        const auto rows = glyph(character);
-        for (int row = 0; row < 7; ++row) {
-            for (int column = 0; column < 5; ++column) {
-                if ((rows[row] & (1u << (4 - column))) != 0) {
-                    surface.fillRect(
-                        glyphX + column * scale, glyphY + row * scale, scale, scale, glyphColor);
-                }
-            }
-        }
-    };
-
-    int cursor = x;
-    for (char character : text) {
-        if (shadow) {
-            drawGlyph(cursor + scale, y + scale, character, {0, 0, 0});
-        }
-        drawGlyph(cursor, y, character, color);
-        cursor += 6 * scale;
+    setfont(textFontHeight(scale), 0, TEXT_FONT_NAME);
+    setbkmode(TRANSPARENT);
+    if (shadow) {
+        setcolor(EGERGB(0, 0, 0));
+        outtextxy(x + scale, y + scale, text.c_str());
     }
+    setcolor(EGERGB(color.r, color.g, color.b));
+    outtextxy(x, y, text.c_str());
 }
 
-// The HUD text is rendered through a small canvas abstraction so the same
-// layout code can drive either the software bitmap font (headless builds, which
-// have no EGE font system) or EGE's native fonts (windowed builds, which need
-// CJK support). Both backends implement draw() and width() with matching
-// signatures; the Game class instantiates them via templates.
-
-// Bitmap font backend: renders into a software Surface using the 5x7 glyphs
-// above. Always available, used by the headless self-test / benchmark / PPM
-// paths so their output stays deterministic and free of system-font coupling.
-class BitmapTextCanvas {
-public:
-    explicit BitmapTextCanvas(Surface& surface) : surface(surface) {}
-
-    void draw(int x, int y, const std::string& text, int scale, Color color, bool shadow = true) const
-    {
-        drawText(surface, x, y, text, scale, color, shadow);
-    }
-
-    int width(const std::string& text, int scale) const
-    {
-        return static_cast<int>(text.size()) * 6 * scale;
-    }
-
-private:
-    Surface& surface;
-};
-
-#ifndef CUBE_RUNNER_HEADLESS
-// EGE native font backend: renders with the window's font system so the HUD can
-// display CJK glyphs. Used by the windowed build only. Font height tracks the
-// bitmap font's 7-pixel glyph rows so the HUD layout is preserved.
-class EgeTextCanvas {
-public:
-    EgeTextCanvas() = default;
-
-    void draw(int x, int y, const std::string& text, int scale, Color color, bool shadow = true) const
-    {
-        setfont(fontHeight(scale), 0, TEXT_FONT_NAME);
-        setbkmode(TRANSPARENT);
-        if (shadow) {
-            setcolor(EGERGB(0, 0, 0));
-            outtextxy(x + scale, y + scale, text.c_str());
-        }
-        setcolor(EGERGB(color.r, color.g, color.b));
-        outtextxy(x, y, text.c_str());
-    }
-
-    int width(const std::string& text, int scale) const
-    {
-        setfont(fontHeight(scale), 0, TEXT_FONT_NAME);
-        return textwidth(text.c_str());
-    }
-
-private:
-    static int fontHeight(int scale) { return std::max(7, 7 * scale); }
-};
-#endif // CUBE_RUNNER_HEADLESS
+int textLineWidth(const std::string& text, int scale)
+{
+    setfont(textFontHeight(scale), 0, TEXT_FONT_NAME);
+    return textwidth(text.c_str());
+}
 
 class Random {
 public:
@@ -796,7 +687,7 @@ public:
     bool isGameOver() const { return gameOver; }
     std::size_t obstacleCount() const { return obstacles.size(); }
 
-    void render(Surface& surface, float framesPerSecond = 0.0f) const
+    void render(Surface& surface) const
     {
         RenderExecutor& executor = renderExecutor();
         const int threadCount = executor.threadCount();
@@ -804,22 +695,18 @@ public:
             const int top = surface.height * threadIndex / threadCount;
             const int bottom = surface.height * (threadIndex + 1) / threadCount;
             RenderBandScope band(top, bottom);
-            renderBand(surface, framesPerSecond);
+            renderBand(surface);
         });
     }
 
-    // Draws the HUD and overlay text. Windowed builds pass an EgeTextCanvas (EGE
-    // native fonts, supports CJK); headless builds render text inside renderBand
-    // with the bitmap font instead, so they do not call this method.
-    template <typename Canvas>
-    void drawText(Canvas& canvas, const Surface& surface, float framesPerSecond) const
-    {
-        drawHudText(canvas, surface, framesPerSecond);
-        drawOverlayText(canvas, surface);
-    }
+    // Draws the HUD and overlay text with EGE's native fonts (so the HUD can
+    // show CJK under MSVC). Called by the windowed main after the frame is
+    // blitted; the text lands on the device backbuffer on top of the image.
+    void drawHud(const Surface& surface, float framesPerSecond) const;
+    void drawOverlay(const Surface& surface) const;
 
 private:
-    void renderBand(Surface& surface, float framesPerSecond) const
+    void renderBand(Surface& surface) const
     {
         surface.clear({2, 4, 10});
         drawTube(surface);
@@ -840,17 +727,6 @@ private:
         if (paused || gameOver) {
             surface.fillRect(0, 0, surface.width, surface.height, {0, 0, 0}, 0.62f);
         }
-
-#ifdef CUBE_RUNNER_HEADLESS
-        // Headless builds render text directly into the surface with the built-in
-        // bitmap font. Windowed builds defer text to drawText() so the HUD can use
-        // EGE's native fonts (and CJK glyphs) after the frame is blitted.
-        BitmapTextCanvas canvas(surface);
-        drawHudText(canvas, surface, framesPerSecond);
-        drawOverlayText(canvas, surface);
-#else
-        (void)framesPerSecond;
-#endif
     }
 
     static int hudScale(const Surface& surface)
@@ -1108,57 +984,6 @@ private:
             {2, 5, 11}, 0.72f);
     }
 
-    template <typename Canvas>
-    void drawHudText(Canvas& canvas, const Surface& surface, float framesPerSecond) const
-    {
-        const int uiScale = hudScale(surface);
-        const int textScale = 2 * uiScale;
-        canvas.draw(26 * uiScale, 24 * uiScale, TEXT_HUD_TITLE, textScale, {115, 235, 255});
-        canvas.draw(26 * uiScale, 48 * uiScale,
-            std::string(TEXT_SCORE) + std::to_string(static_cast<int>(score)), textScale,
-            {245, 248, 255});
-
-        const std::string status = std::string(TEXT_LIVES) + std::to_string(lives)
-            + "   " + TEXT_STAGE + std::to_string(stage + 1);
-        const int statusWidth = canvas.width(status, textScale);
-        canvas.draw(surface.width - statusWidth - 18 * uiScale, 24 * uiScale,
-            status, textScale, {255, 225, 70});
-
-        const std::string fps = std::string(TEXT_FPS)
-            + std::to_string(std::max(0, static_cast<int>(framesPerSecond + 0.5f)));
-        const int fpsWidth = canvas.width(fps, textScale);
-        canvas.draw(surface.width - fpsWidth - 18 * uiScale, 48 * uiScale,
-            fps, textScale, {115, 235, 255});
-
-        const int controlsScale = uiScale;
-        const int controlsWidth = canvas.width(TEXT_CONTROLS, controlsScale);
-        canvas.draw((surface.width - controlsWidth) / 2,
-            surface.height - 22 * uiScale, TEXT_CONTROLS, controlsScale,
-            {190, 220, 240}, false);
-    }
-
-    template <typename Canvas>
-    void drawOverlayText(Canvas& canvas, const Surface& surface) const
-    {
-        if (!paused && !gameOver) {
-            return;
-        }
-
-        const std::string message = gameOver ? TEXT_GAME_OVER : TEXT_PAUSED;
-        const int uiScale = hudScale(surface);
-        const int scale = 5 * uiScale;
-        const int messageWidth = canvas.width(message, scale);
-        const int messageY = static_cast<int>(surface.height * 0.40f);
-        canvas.draw((surface.width - messageWidth) / 2, messageY, message, scale,
-            gameOver ? Color {255, 80, 70} : Color {255, 220, 70});
-
-        const std::string action = gameOver ? TEXT_ACTION_RESTART : TEXT_ACTION_RESUME;
-        const int actionScale = 2 * uiScale;
-        const int actionWidth = canvas.width(action, actionScale);
-        canvas.draw((surface.width - actionWidth) / 2, messageY + 52 * uiScale,
-            action, actionScale, {220, 235, 255});
-    }
-
     Random                random;
     std::vector<Obstacle> obstacles;
     double                elapsed {0.0};
@@ -1177,23 +1002,53 @@ private:
     bool                  collisionsEnabled {true};
 };
 
-bool savePpm(const Surface& surface, const std::string& path)
+void Game::drawHud(const Surface& surface, float framesPerSecond) const
 {
-    std::ofstream file(path, std::ios::binary);
-    if (!file) {
-        return false;
+    const int uiScale = hudScale(surface);
+    const int textScale = 2 * uiScale;
+    drawTextLine(26 * uiScale, 24 * uiScale, TEXT_HUD_TITLE, textScale, {115, 235, 255});
+    drawTextLine(26 * uiScale, 48 * uiScale,
+        std::string(TEXT_SCORE) + std::to_string(static_cast<int>(score)), textScale,
+        {245, 248, 255});
+
+    const std::string status = std::string(TEXT_LIVES) + std::to_string(lives)
+        + "   " + TEXT_STAGE + std::to_string(stage + 1);
+    const int statusWidth = textLineWidth(status, textScale);
+    drawTextLine(surface.width - statusWidth - 18 * uiScale, 24 * uiScale,
+        status, textScale, {255, 225, 70});
+
+    const std::string fps = std::string(TEXT_FPS)
+        + std::to_string(std::max(0, static_cast<int>(framesPerSecond + 0.5f)));
+    const int fpsWidth = textLineWidth(fps, textScale);
+    drawTextLine(surface.width - fpsWidth - 18 * uiScale, 48 * uiScale,
+        fps, textScale, {115, 235, 255});
+
+    const int controlsScale = uiScale;
+    const int controlsWidth = textLineWidth(TEXT_CONTROLS, controlsScale);
+    drawTextLine((surface.width - controlsWidth) / 2,
+        surface.height - 22 * uiScale, TEXT_CONTROLS, controlsScale,
+        {190, 220, 240}, false);
+}
+
+void Game::drawOverlay(const Surface& surface) const
+{
+    if (!paused && !gameOver) {
+        return;
     }
 
-    file << "P6\n" << surface.width << ' ' << surface.height << "\n255\n";
-    for (std::uint32_t pixel : surface.pixels) {
-        const std::array<char, 3> rgb {{
-            static_cast<char>((pixel >> 16) & 0xff),
-            static_cast<char>((pixel >> 8) & 0xff),
-            static_cast<char>(pixel & 0xff),
-        }};
-        file.write(rgb.data(), rgb.size());
-    }
-    return static_cast<bool>(file);
+    const std::string message = gameOver ? TEXT_GAME_OVER : TEXT_PAUSED;
+    const int uiScale = hudScale(surface);
+    const int scale = 5 * uiScale;
+    const int messageWidth = textLineWidth(message, scale);
+    const int messageY = static_cast<int>(surface.height * 0.40f);
+    drawTextLine((surface.width - messageWidth) / 2, messageY, message, scale,
+        gameOver ? Color {255, 80, 70} : Color {255, 220, 70});
+
+    const std::string action = gameOver ? TEXT_ACTION_RESTART : TEXT_ACTION_RESUME;
+    const int actionScale = 2 * uiScale;
+    const int actionWidth = textLineWidth(action, actionScale);
+    drawTextLine((surface.width - actionWidth) / 2, messageY + 52 * uiScale,
+        action, actionScale, {220, 235, 255});
 }
 
 bool parseResolution(const std::string& text, int& width, int& height)
@@ -1222,272 +1077,6 @@ bool parseResolution(const std::string& text, int& width, int& height)
 }
 
 } // namespace cube_runner
-
-#ifdef CUBE_RUNNER_HEADLESS
-
-namespace {
-
-bool nearlyEqual(double actual, double expected, double tolerance)
-{
-    return std::abs(actual - expected) <= tolerance;
-}
-
-std::size_t changedPlayfieldPixels(
-    const cube_runner::Surface& first, const cube_runner::Surface& second)
-{
-    std::size_t changed = 0;
-    const int top = first.height * 90 / 480;
-    const int bottom = first.height - first.height * 32 / 480;
-    for (int y = top; y < bottom; ++y) {
-        for (int x = 0; x < first.width; ++x) {
-            const std::size_t index = static_cast<std::size_t>(y) * first.width + x;
-            if (first.pixels[index] != second.pixels[index]) {
-                ++changed;
-            }
-        }
-    }
-    return changed;
-}
-
-bool runSelfTest()
-{
-    constexpr float deltaTime = 1.0f / cube_runner::kReferenceFps;
-    bool passed = true;
-    auto require = [&](bool condition, const char* message) {
-        if (!condition) {
-            std::cerr << "SELF-TEST FAILED: " << message << '\n';
-            passed = false;
-        }
-    };
-
-    cube_runner::Game movementGame(false);
-    cube_runner::Surface before;
-    cube_runner::Surface after;
-    movementGame.render(before);
-    movementGame.update(deltaTime, false, false);
-    movementGame.render(after);
-
-    require(nearlyEqual(movementGame.speed(), cube_runner::kBaseSpeed, 0.0001),
-        "initial speed does not match the browser game");
-    require(nearlyEqual(movementGame.distance(), 0.14, 0.0001),
-        "one frame does not advance by 0.14 world units");
-    require(changedPlayfieldPixels(before, after) > 500,
-        "the tunnel playfield did not visibly move after one frame");
-
-    cube_runner::Surface lineSurface(640, 480);
-    lineSurface.clear({255, 255, 255});
-    cube_runner::rasterLine(lineSurface, {-0.5f, 0.0f, 2.0f}, {0.5f, 0.25f, 2.0f},
-        {0, 0, 0});
-    const std::size_t blendedLinePixels = static_cast<std::size_t>(std::count_if(
-        lineSurface.pixels.begin(), lineSurface.pixels.end(), [](std::uint32_t pixel) {
-            const std::uint32_t rgb = pixel & 0x00ffffffu;
-            return rgb != 0x00ffffffu && rgb != 0u;
-        }));
-    require(blendedLinePixels > 0,
-        "line rasterization did not produce antialiased edge coverage");
-
-    cube_runner::Surface fpsZero(800, 600);
-    cube_runner::Surface fpsSixty(800, 600);
-    movementGame.render(fpsZero, 0.0f);
-    movementGame.render(fpsSixty, 60.0f);
-    require(fpsZero.pixels != fpsSixty.pixels,
-        "the FPS value was not drawn into the HUD");
-
-    int parsedWidth = 0;
-    int parsedHeight = 0;
-    require(cube_runner::parseResolution("1280x720", parsedWidth, parsedHeight)
-            && parsedWidth == 1280 && parsedHeight == 720,
-        "a valid runtime resolution was rejected");
-    require(!cube_runner::parseResolution("1280-by-720", parsedWidth, parsedHeight),
-        "an invalid runtime resolution was accepted");
-    require(cube_runner::renderThreadCount() >= 1
-            && cube_runner::renderThreadCount() <= 4
-            && cube_runner::renderThreadCount() <= CUBE_RUNNER_MAX_RENDER_THREADS,
-        "the render worker count is outside the configured limit");
-
-    cube_runner::KeyPressLatch keyLatch;
-    require(keyLatch.update(false, 1),
-        "a short key press between frames was lost");
-    require(!keyLatch.update(false, 0),
-        "a consumed short key press was repeated");
-    require(keyLatch.update(true, 0) && !keyLatch.update(true, 0),
-        "a held key did not generate exactly one down edge");
-    require(!keyLatch.update(false, 0) && keyLatch.update(true, 0),
-        "a released key could not be pressed again");
-
-    for (int frame = 1; frame < static_cast<int>(cube_runner::kReferenceFps); ++frame) {
-        movementGame.update(deltaTime, false, false);
-    }
-    require(nearlyEqual(movementGame.distance(), cube_runner::kBaseSpeed, 0.001),
-        "one second of simulation did not cover the expected distance");
-    require(movementGame.obstacleCount() > 0,
-        "distance-based spawning did not create an obstacle");
-
-    cube_runner::Game keyboardGame(false);
-    for (int frame = 0; frame < 30; ++frame) {
-        keyboardGame.update(deltaTime, false, true);
-    }
-    require(keyboardGame.rotationAngle() > cube_runner::kTrackAngle * 2.0f,
-        "holding a turn key does not rotate the tunnel responsively");
-
-    cube_runner::Game dragGame(false);
-    dragGame.update(deltaTime, false, false, cube_runner::kTrackAngle);
-    require(nearlyEqual(dragGame.rotationAngle(), cube_runner::kTrackAngle, 0.0001),
-        "mouse drag rotation was not applied directly");
-
-    const double distanceBeforePause = movementGame.distance();
-    movementGame.togglePause();
-    movementGame.update(1.0f, false, false);
-    require(nearlyEqual(movementGame.distance(), distanceBeforePause, 0.000001),
-        "pausing did not stop forward movement");
-
-    cube_runner::Game resetGame(false);
-    for (int frame = 0; frame < 120; ++frame) {
-        resetGame.update(deltaTime, false, false);
-    }
-    resetGame.reset();
-    require(!resetGame.isGameOver() && resetGame.livesRemaining() == 3
-            && nearlyEqual(resetGame.distance(), 0.0, 0.000001)
-            && resetGame.obstacleCount() == 0,
-        "reset did not restore a fresh playable game");
-
-    cube_runner::Game gameOverResetGame;
-    for (int frame = 0; frame < 18000 && !gameOverResetGame.isGameOver(); ++frame) {
-        gameOverResetGame.update(deltaTime, false, false);
-    }
-    require(gameOverResetGame.isGameOver(),
-        "the deterministic collision scenario did not reach game over");
-    gameOverResetGame.reset();
-    require(!gameOverResetGame.isGameOver() && gameOverResetGame.livesRemaining() == 3,
-        "reset did not recover from game over");
-
-    cube_runner::Game stageGame(false);
-    const int framesPerStage = static_cast<int>(
-        cube_runner::kStageDuration * cube_runner::kReferenceFps) + 1;
-    for (int frame = 0; frame < framesPerStage; ++frame) {
-        stageGame.update(deltaTime, false, false);
-    }
-    require(stageGame.currentStage() == 1 && stageGame.currentLevel() == 0,
-        "the first stage did not last about 30 seconds");
-
-    cube_runner::Game levelGame(false);
-    const int framesPerLevel = static_cast<int>(cube_runner::kStageDuration
-        * cube_runner::kStageCount * cube_runner::kReferenceFps) + 1;
-    for (int frame = 0; frame < framesPerLevel; ++frame) {
-        levelGame.update(deltaTime, false, false);
-    }
-    require(levelGame.currentStage() == 0 && levelGame.currentLevel() == 1,
-        "eight stages did not advance to the next level");
-    require(nearlyEqual(levelGame.speed(),
-                cube_runner::kBaseSpeed + cube_runner::kLevelSpeedStep, 0.0001),
-        "level speed increase does not match the browser game");
-
-    if (passed) {
-        std::cout << "Cube Runner self-test passed: motion, controls, antialiased lines, "
-                     "FPS HUD, runtime resolution, spawning, and progression\n";
-    }
-    return passed;
-}
-
-int runBenchmark(int width, int height, int frameCount)
-{
-    constexpr float deltaTime = 1.0f / cube_runner::kReferenceFps;
-    cube_runner::Game game(false);
-    cube_runner::Surface surface(width, height);
-
-    for (int frame = 0; frame < 30; ++frame) {
-        game.update(deltaTime, false, false);
-        game.render(surface);
-    }
-
-    const auto start = std::chrono::steady_clock::now();
-    for (int frame = 0; frame < frameCount; ++frame) {
-        const bool turnLeft = (frame % 240) >= 60 && (frame % 240) < 105;
-        const bool turnRight = (frame % 240) >= 155 && (frame % 240) < 210;
-        game.update(deltaTime, turnLeft, turnRight);
-        game.render(surface);
-    }
-    const auto finish = std::chrono::steady_clock::now();
-    const double seconds = std::chrono::duration<double>(finish - start).count();
-    const double framesPerSecond = frameCount / seconds;
-    const double millisecondsPerFrame = seconds * 1000.0 / frameCount;
-
-    std::uint64_t checksum = 0;
-    for (std::size_t index = 0; index < surface.pixels.size(); index += 997) {
-        checksum = checksum * 131u + surface.pixels[index];
-    }
-
-    std::cout << "BENCHMARK " << width << 'x' << height
-              << " frames=" << frameCount
-              << " threads=" << cube_runner::renderThreadCount()
-              << std::fixed << std::setprecision(2)
-              << " fps=" << framesPerSecond
-              << " ms/frame=" << millisecondsPerFrame
-              << " checksum=" << checksum << '\n';
-    return EXIT_SUCCESS;
-}
-
-} // namespace
-
-int main(int argc, char** argv)
-{
-    if (argc > 1 && std::string(argv[1]) == "--self-test") {
-        return runSelfTest() ? EXIT_SUCCESS : EXIT_FAILURE;
-    }
-    if (argc > 1 && std::string(argv[1]) == "--benchmark") {
-        int width = cube_runner::kDefaultWidth;
-        int height = cube_runner::kDefaultHeight;
-        if (argc < 3 || !cube_runner::parseResolution(argv[2], width, height)) {
-            std::cerr << "Usage: --benchmark WIDTHxHEIGHT [frames]\n";
-            return EXIT_FAILURE;
-        }
-        const int frameCount = argc > 3 ? std::max(1, std::atoi(argv[3])) : 240;
-        return runBenchmark(width, height, frameCount);
-    }
-
-    int width = cube_runner::kDefaultWidth;
-    int height = cube_runner::kDefaultHeight;
-    int argumentOffset = 0;
-    if (argc > 1 && std::string(argv[1]) == "--render") {
-        if (argc < 3 || !cube_runner::parseResolution(argv[2], width, height)) {
-            std::cerr << "Usage: --render WIDTHxHEIGHT [output.ppm] [frames]\n";
-            return EXIT_FAILURE;
-        }
-        argumentOffset = 2;
-    } else if (argc > 1 && argv[1][0] == '-') {
-        // Reject unknown options instead of silently treating them as the output
-        // filename, mirroring the interactive main's argument validation.
-        std::cerr << "Unknown argument: " << argv[1] << '\n';
-        std::cerr << "Usage: --self-test | --benchmark WIDTHxHEIGHT [frames]"
-                     " | --render WIDTHxHEIGHT [output.ppm] [frames] | [output.ppm]\n";
-        return EXIT_FAILURE;
-    }
-
-    const std::string outputPath = argc > argumentOffset + 1
-        ? argv[argumentOffset + 1] : "cube_runner.ppm";
-    const int frameCount = argc > argumentOffset + 2
-        ? std::max(1, std::atoi(argv[argumentOffset + 2])) : 360;
-
-    cube_runner::Game game(false);
-    for (int frame = 0; frame < frameCount; ++frame) {
-        const bool turnLeft  = (frame > 160 && frame < 205);
-        const bool turnRight = (frame > 275 && frame < 330);
-        game.update(1.0f / 60.0f, turnLeft, turnRight);
-    }
-
-    cube_runner::Surface surface(width, height);
-    game.render(surface);
-    if (!cube_runner::savePpm(surface, outputPath)) {
-        std::cerr << "Failed to save " << outputPath << '\n';
-        return 1;
-    }
-
-    std::cout << "Saved " << outputPath << " (" << surface.width << 'x'
-              << surface.height << ")\n";
-    return 0;
-}
-
-#else
 
 int main(int argc, char** argv)
 {
@@ -1534,9 +1123,8 @@ int main(int argc, char** argv)
         closeWindow();
         return EXIT_FAILURE;
     }
-    Surface surface(width, height);
+    Surface surface(width, height, getbuffer(frameImage));
     Game game;
-    EgeTextCanvas textCanvas;
     bool dragging = false;
     int lastMouseX = 0;
     int renderedFrames = 0;
@@ -1577,12 +1165,12 @@ int main(int argc, char** argv)
         const bool turnRight = keystate(key_right) || keystate(key_D);
         const float framesPerSecond = getfps();
         game.update(1.0f / 60.0f, turnLeft, turnRight, dragRotation);
-        game.render(surface, framesPerSecond);
-
-        color_t* destination = getbuffer(frameImage);
-        std::copy(surface.pixels.begin(), surface.pixels.end(), destination);
+        // render() writes directly into frameImage's buffer (Surface borrows it),
+        // so there is no per-frame copy before the blit.
+        game.render(surface);
         putimage(0, 0, frameImage);
-        game.drawText(textCanvas, surface, framesPerSecond);
+        game.drawHud(surface, framesPerSecond);
+        game.drawOverlay(surface);
         ++renderedFrames;
         if (exitAfterFrames > 0 && renderedFrames >= exitAfterFrames) {
             break;
@@ -1595,4 +1183,3 @@ int main(int argc, char** argv)
     return 0;
 }
 
-#endif

--- a/demo/game_cube_runner.cpp
+++ b/demo/game_cube_runner.cpp
@@ -22,6 +22,7 @@ constexpr int   kWidth       = 640;
 constexpr int   kHeight      = 480;
 constexpr int   kTracks      = 12;
 constexpr int   kTubeRows    = 24;
+constexpr int   kStageCount  = 8;
 constexpr float kPi          = 3.14159265358979323846f;
 constexpr float kTrackAngle  = 2.0f * kPi / kTracks;
 const     float kTileSize    = 2.0f * std::sin(kPi / kTracks);
@@ -32,6 +33,15 @@ const     float kFogNear     = kFarPlane * 0.25f;
 constexpr float kCameraY     = -0.5f;
 constexpr float kPlayerAngle = -kPi * 0.5f;
 const     float kFocalLength = (kHeight * 0.5f) / std::tan(75.0f * kPi / 360.0f);
+// The browser game advances 0.14 world units per 60 Hz frame and adds
+// 0.02 units per frame after each complete eight-stage level.
+constexpr float kReferenceFps   = 60.0f;
+constexpr float kBaseSpeed      = 0.14f * kReferenceFps;
+constexpr float kLevelSpeedStep = 0.02f * kReferenceFps;
+constexpr float kStageDuration  = 30.0f;
+constexpr float kTubeStart      = 0.42f;
+constexpr float kKeyboardTurnSpeed = kTrackAngle * 8.0f;
+constexpr float kMouseDragSensitivity = kTrackAngle / 56.0f;
 
 struct Vec3 {
     float x;
@@ -405,8 +415,9 @@ float wrapAngle(float angle)
 
 class Game {
 public:
-    Game()
-        : random(0x58454745u)
+    explicit Game(bool collisionsEnabled = true)
+        : random(0x58454745u),
+          collisionsEnabled(collisionsEnabled)
     {
         reset();
     }
@@ -416,12 +427,15 @@ public:
         obstacles.clear();
         elapsed         = 0.0f;
         score           = 0.0f;
+        forwardDistance = 0.0;
         rotation        = 0.0f;
         angularVelocity = 0.0f;
-        spawnTimer      = 0.35f;
+        currentSpeed    = kBaseSpeed;
+        spawnDistance   = 6.0 * kTileSize;
         invincible      = 0.0f;
         lives           = 3;
         stage           = 0;
+        level           = 0;
         paused          = false;
         gameOver        = false;
     }
@@ -431,27 +445,33 @@ public:
         if (!gameOver) paused = !paused;
     }
 
-    void update(float deltaTime, bool turnLeft, bool turnRight)
+    void update(float deltaTime, bool turnLeft, bool turnRight, float dragRotation = 0.0f)
     {
         if (paused || gameOver) {
             return;
         }
 
         elapsed += deltaTime;
-        stage = static_cast<int>(elapsed / 18.0f) % 8;
-        const float speed = 2.55f + 0.16f * static_cast<int>(elapsed / 18.0f);
-        score += speed * deltaTime * 10.0f;
+        const int stageProgress = static_cast<int>(elapsed / kStageDuration);
+        stage = stageProgress % kStageCount;
+        level = stageProgress / kStageCount;
+        currentSpeed = kBaseSpeed + kLevelSpeedStep * level;
+        const float frameDistance = currentSpeed * deltaTime;
+        forwardDistance += frameDistance;
+        score += kReferenceFps * deltaTime;
         invincible = std::max(0.0f, invincible - deltaTime);
 
-        const float targetVelocity = (turnRight ? 1.9f : 0.0f) - (turnLeft ? 1.9f : 0.0f);
-        angularVelocity += (targetVelocity - angularVelocity) * std::min(1.0f, deltaTime * 8.0f);
+        const float steering = (turnRight ? 1.0f : 0.0f) - (turnLeft ? 1.0f : 0.0f);
+        const float targetVelocity = steering * kKeyboardTurnSpeed;
+        angularVelocity +=
+            (targetVelocity - angularVelocity) * std::min(1.0f, deltaTime * 18.0f);
         if (!turnLeft && !turnRight) {
             angularVelocity *= std::pow(0.12f, deltaTime);
         }
-        rotation = wrapAngle(rotation + angularVelocity * deltaTime);
+        rotation = wrapAngle(rotation + angularVelocity * deltaTime + dragRotation);
 
         for (Obstacle& obstacle : obstacles) {
-            obstacle.z -= speed * obstacle.speedScale * deltaTime;
+            obstacle.z -= frameDistance * obstacle.speedScale;
         }
 
         checkCollisions();
@@ -459,11 +479,18 @@ public:
                             [](const Obstacle& obstacle) { return obstacle.z < 0.22f; }),
             obstacles.end());
 
-        spawnTimer -= deltaTime;
-        if (spawnTimer <= 0.0f) {
+        spawnDistance -= frameDistance;
+        while (spawnDistance <= 0.0) {
             spawnPattern();
         }
     }
+
+    float speed() const { return currentSpeed; }
+    double distance() const { return forwardDistance; }
+    float rotationAngle() const { return rotation; }
+    int currentStage() const { return stage; }
+    int currentLevel() const { return level; }
+    std::size_t obstacleCount() const { return obstacles.size(); }
 
     void render(Surface& surface) const
     {
@@ -517,33 +544,27 @@ private:
         switch (stage) {
         case 0:
             spawnOne(track, random.range(3));
-            spawnTimer = 0.82f;
             break;
         case 1:
             spawnOne(track, 6, 0.76f, 0.72f, 0.82f, 1.28f);
-            spawnTimer = 0.92f;
             break;
         case 2:
             spawnOne(track, 3 + random.range(3), 0.82f, 1.18f, 0.92f);
-            spawnTimer = 1.15f;
             break;
         case 3:
             spawnOne(track, 8, 0.82f, 1.75f, 0.88f);
-            spawnTimer = 1.25f;
             break;
         case 4:
             spawnOne(track, random.range(3));
             if (random.range(4) == 0) {
                 spawnOne((track + 3 + random.range(4)) % kTracks, 11, 0.78f, 1.55f, 0.86f);
             }
-            spawnTimer = 0.74f;
             break;
         case 5: {
             const int count = 4 + 2 * random.range(3);
             for (int i = 0; i < count; ++i) {
                 spawnOne((track + i) % kTracks, 12);
             }
-            spawnTimer = 1.55f;
             break;
         }
         case 6:
@@ -552,19 +573,28 @@ private:
                 spawnOne((track + 1) % kTracks, 12, 0.75f, 0.75f, 0.82f, 1.0f, 0.32f);
                 spawnOne((track + 2) % kTracks, 12, 0.75f, 0.75f, 0.82f, 1.0f, 0.64f);
             }
-            spawnTimer = 0.64f;
             break;
         default:
             spawnOne(track, 9, 2.65f, 1.7f, 0.9f);
             spawnOne((track + 5 + random.range(3)) % kTracks, 7, 0.76f, 0.76f, 0.82f, 1.2f, 0.5f);
-            spawnTimer = 1.42f;
             break;
         }
+
+        float spacingInTiles = 6.0f;
+        switch (stage) {
+        case 2: spacingInTiles = 8.0f + 2.0f * level; break;
+        case 3:
+        case 7: spacingInTiles = 10.0f; break;
+        case 4: spacingInTiles = 6.0f + 2.0f * level; break;
+        case 6: spacingInTiles = 6.0f + 3.0f * level; break;
+        default: break;
+        }
+        spawnDistance += spacingInTiles * kTileSize;
     }
 
     void checkCollisions()
     {
-        if (invincible > 0.0f) {
+        if (!collisionsEnabled || invincible > 0.0f) {
             return;
         }
 
@@ -603,16 +633,31 @@ private:
     {
         const bool brightStage = (stage % 2) == 0;
         const float brightness = brightStage ? 1.0f : 0.34f;
+        const double tilePosition = forwardDistance / kTileSize;
+        const long long passedTiles = static_cast<long long>(std::floor(tilePosition));
+        const float tubeOffset = static_cast<float>(
+            forwardDistance - static_cast<double>(passedTiles) * kTileSize);
+        const float firstRowZ = kTubeStart - tubeOffset;
+        const float clippedNear = kNearPlane + 0.001f;
 
-        for (int row = 0; row < kTubeRows; ++row) {
-            const float z0 = 0.42f + row * kTileSize;
-            const float z1 = z0 + kTileSize;
+        // Start one row behind the near plane. That extra row replaces the one
+        // that just passed the player and keeps the tunnel continuous when the
+        // offset wraps at a tile boundary.
+        for (int row = -1; row < kTubeRows; ++row) {
+            const float rawZ0 = firstRowZ + row * kTileSize;
+            const float rawZ1 = rawZ0 + kTileSize;
+            if (rawZ1 <= clippedNear) {
+                continue;
+            }
+            const float z0 = std::max(rawZ0, clippedNear);
+            const float z1 = rawZ1;
             for (int track = 0; track < kTracks; ++track) {
                 const Vec3 p00 = tubePoint(track, z0);
                 const Vec3 p10 = tubePoint(track + 1, z0);
                 const Vec3 p11 = tubePoint(track + 1, z1);
                 const Vec3 p01 = tubePoint(track, z1);
-                const float checker = ((track + row) & 1) ? 0.93f : 1.0f;
+                const bool alternate = ((track + row + passedTiles) & 1LL) != 0;
+                const float checker = alternate ? 0.93f : 1.0f;
                 const Color tile = scaleColor({224, 234, 244}, brightness * checker);
                 rasterTriangle(surface, p00, p10, p11, tile);
                 rasterTriangle(surface, p00, p11, p01, tile);
@@ -620,15 +665,23 @@ private:
         }
 
         const Color grid = brightStage ? Color {25, 42, 58} : Color {4, 8, 13};
-        for (int row = 0; row <= kTubeRows; ++row) {
-            const float z = 0.42f + row * kTileSize;
+        for (int row = -1; row <= kTubeRows; ++row) {
+            const float z = firstRowZ + row * kTileSize;
+            if (z <= clippedNear) {
+                continue;
+            }
             for (int track = 0; track < kTracks; ++track) {
                 rasterLine(surface, tubePoint(track, z), tubePoint(track + 1, z), grid);
             }
         }
-        for (int row = 0; row < kTubeRows; ++row) {
-            const float z0 = 0.42f + row * kTileSize;
-            const float z1 = z0 + kTileSize;
+        for (int row = -1; row < kTubeRows; ++row) {
+            const float rawZ0 = firstRowZ + row * kTileSize;
+            const float rawZ1 = rawZ0 + kTileSize;
+            if (rawZ1 <= clippedNear) {
+                continue;
+            }
+            const float z0 = std::max(rawZ0, clippedNear);
+            const float z1 = rawZ1;
             for (int track = 0; track < kTracks; ++track) {
                 rasterLine(surface, tubePoint(track, z0), tubePoint(track, z1), grid);
             }
@@ -717,22 +770,29 @@ private:
         drawText(surface, kWidth - statusWidth - 18, 24, status, 2, {255, 225, 70});
 
         surface.fillRect(0, kHeight - 31, kWidth, 31, {2, 5, 11}, 0.72f);
-        drawText(surface, 88, kHeight - 22, "[A/D] STEER   [P] PAUSE   [R] RESTART", 1,
+        const std::string controls =
+            "[A/D] OR DRAG TO STEER   [P] PAUSE   [R] RESTART";
+        const int controlsWidth = static_cast<int>(controls.size()) * 6;
+        drawText(surface, (kWidth - controlsWidth) / 2, kHeight - 22, controls, 1,
             {190, 220, 240}, false);
     }
 
     Random                random;
     std::vector<Obstacle> obstacles;
-    float                 elapsed {0.0f};
+    double                elapsed {0.0};
     float                 score {0.0f};
+    double                forwardDistance {0.0};
     float                 rotation {0.0f};
     float                 angularVelocity {0.0f};
-    float                 spawnTimer {0.0f};
+    float                 currentSpeed {kBaseSpeed};
+    double                spawnDistance {0.0};
     float                 invincible {0.0f};
     int                   lives {3};
     int                   stage {0};
+    int                   level {0};
     bool                  paused {false};
     bool                  gameOver {false};
+    bool                  collisionsEnabled {true};
 };
 
 bool savePpm(const Surface& surface, const std::string& path)
@@ -761,12 +821,119 @@ bool savePpm(const Surface& surface, const std::string& path)
 #include <cstdlib>
 #include <iostream>
 
+namespace {
+
+bool nearlyEqual(double actual, double expected, double tolerance)
+{
+    return std::abs(actual - expected) <= tolerance;
+}
+
+std::size_t changedPlayfieldPixels(
+    const cube_runner::Surface& first, const cube_runner::Surface& second)
+{
+    std::size_t changed = 0;
+    for (int y = 90; y < cube_runner::kHeight - 32; ++y) {
+        for (int x = 0; x < cube_runner::kWidth; ++x) {
+            const std::size_t index = static_cast<std::size_t>(y) * cube_runner::kWidth + x;
+            if (first.pixels[index] != second.pixels[index]) {
+                ++changed;
+            }
+        }
+    }
+    return changed;
+}
+
+bool runSelfTest()
+{
+    constexpr float deltaTime = 1.0f / cube_runner::kReferenceFps;
+    bool passed = true;
+    auto require = [&](bool condition, const char* message) {
+        if (!condition) {
+            std::cerr << "SELF-TEST FAILED: " << message << '\n';
+            passed = false;
+        }
+    };
+
+    cube_runner::Game movementGame(false);
+    cube_runner::Surface before;
+    cube_runner::Surface after;
+    movementGame.render(before);
+    movementGame.update(deltaTime, false, false);
+    movementGame.render(after);
+
+    require(nearlyEqual(movementGame.speed(), cube_runner::kBaseSpeed, 0.0001),
+        "initial speed does not match the browser game");
+    require(nearlyEqual(movementGame.distance(), 0.14, 0.0001),
+        "one frame does not advance by 0.14 world units");
+    require(changedPlayfieldPixels(before, after) > 500,
+        "the tunnel playfield did not visibly move after one frame");
+
+    for (int frame = 1; frame < static_cast<int>(cube_runner::kReferenceFps); ++frame) {
+        movementGame.update(deltaTime, false, false);
+    }
+    require(nearlyEqual(movementGame.distance(), cube_runner::kBaseSpeed, 0.001),
+        "one second of simulation did not cover the expected distance");
+    require(movementGame.obstacleCount() > 0,
+        "distance-based spawning did not create an obstacle");
+
+    cube_runner::Game keyboardGame(false);
+    for (int frame = 0; frame < 30; ++frame) {
+        keyboardGame.update(deltaTime, false, true);
+    }
+    require(keyboardGame.rotationAngle() > cube_runner::kTrackAngle * 2.0f,
+        "holding a turn key does not rotate the tunnel responsively");
+
+    cube_runner::Game dragGame(false);
+    dragGame.update(deltaTime, false, false, cube_runner::kTrackAngle);
+    require(nearlyEqual(dragGame.rotationAngle(), cube_runner::kTrackAngle, 0.0001),
+        "mouse drag rotation was not applied directly");
+
+    const double distanceBeforePause = movementGame.distance();
+    movementGame.togglePause();
+    movementGame.update(1.0f, false, false);
+    require(nearlyEqual(movementGame.distance(), distanceBeforePause, 0.000001),
+        "pausing did not stop forward movement");
+
+    cube_runner::Game stageGame(false);
+    const int framesPerStage = static_cast<int>(
+        cube_runner::kStageDuration * cube_runner::kReferenceFps) + 1;
+    for (int frame = 0; frame < framesPerStage; ++frame) {
+        stageGame.update(deltaTime, false, false);
+    }
+    require(stageGame.currentStage() == 1 && stageGame.currentLevel() == 0,
+        "the first stage did not last about 30 seconds");
+
+    cube_runner::Game levelGame(false);
+    const int framesPerLevel = static_cast<int>(cube_runner::kStageDuration
+        * cube_runner::kStageCount * cube_runner::kReferenceFps) + 1;
+    for (int frame = 0; frame < framesPerLevel; ++frame) {
+        levelGame.update(deltaTime, false, false);
+    }
+    require(levelGame.currentStage() == 0 && levelGame.currentLevel() == 1,
+        "eight stages did not advance to the next level");
+    require(nearlyEqual(levelGame.speed(),
+                cube_runner::kBaseSpeed + cube_runner::kLevelSpeedStep, 0.0001),
+        "level speed increase does not match the browser game");
+
+    if (passed) {
+        std::cout << "Cube Runner self-test passed: speed, tunnel motion, spawning, pause, "
+                     "stages, and level progression\n";
+    }
+    return passed;
+}
+
+} // namespace
+
 int main(int argc, char** argv)
 {
+    if (argc > 1 && std::string(argv[1]) == "--self-test") {
+        return runSelfTest() ? EXIT_SUCCESS : EXIT_FAILURE;
+    }
+
     const std::string outputPath = argc > 1 ? argv[1] : "cube_runner.ppm";
     const int frameCount = argc > 2 ? std::max(1, std::atoi(argv[2])) : 360;
 
-    cube_runner::Game game;
+    cube_runner::Game game(false);
     for (int frame = 0; frame < frameCount; ++frame) {
         const bool turnLeft  = (frame > 160 && frame < 205);
         const bool turnRight = (frame > 275 && frame < 330);
@@ -799,6 +966,8 @@ int main()
     PIMAGE frameImage = newimage(kWidth, kHeight);
     Surface surface;
     Game game;
+    bool dragging = false;
+    int lastMouseX = 0;
 
     for (; is_run(); delay_fps(60)) {
         if (keypress(key_esc)) {
@@ -811,9 +980,26 @@ int main()
             game.reset();
         }
 
+        float dragRotation = 0.0f;
+        while (mousemsg()) {
+            const mouse_msg message = getmouse();
+            if (message.is_down() && message.is_left()) {
+                dragging = true;
+                lastMouseX = message.x;
+            } else if (message.is_up() && message.is_left()) {
+                dragging = false;
+            } else if (message.is_move() && dragging) {
+                dragRotation += (message.x - lastMouseX) * kMouseDragSensitivity;
+                lastMouseX = message.x;
+            }
+        }
+        if (dragging && !keystate(key_mouse_l)) {
+            dragging = false;
+        }
+
         const bool turnLeft  = keystate(key_left) || keystate(key_A);
         const bool turnRight = keystate(key_right) || keystate(key_D);
-        game.update(1.0f / 60.0f, turnLeft, turnRight);
+        game.update(1.0f / 60.0f, turnLeft, turnRight, dragRotation);
         game.render(surface);
 
         color_t* destination = getbuffer(frameImage);

--- a/demo/game_cube_runner.cpp
+++ b/demo/game_cube_runner.cpp
@@ -1,0 +1,829 @@
+// Cube Runner - a compact software-rendered 3D game for XEGE.
+//
+// Inspired by https://www.game5.com.de/cuberunner/index.html. The geometry,
+// rasterizer, HUD, and game logic below are original and use no external assets.
+
+#ifndef CUBE_RUNNER_HEADLESS
+#include <graphics.h>
+#endif
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace cube_runner {
+
+constexpr int   kWidth       = 640;
+constexpr int   kHeight      = 480;
+constexpr int   kTracks      = 12;
+constexpr int   kTubeRows    = 24;
+constexpr float kPi          = 3.14159265358979323846f;
+constexpr float kTrackAngle  = 2.0f * kPi / kTracks;
+constexpr float kTileSize    = 2.0f * std::sin(kPi / kTracks);
+constexpr float kTubeRadius  = 1.0f;
+constexpr float kNearPlane   = 0.18f;
+constexpr float kFarPlane    = kTileSize * kTubeRows;
+constexpr float kFogNear     = kFarPlane * 0.25f;
+constexpr float kCameraY     = -0.5f;
+constexpr float kPlayerAngle = -kPi * 0.5f;
+constexpr float kFocalLength = (kHeight * 0.5f) / std::tan(75.0f * kPi / 360.0f);
+
+struct Vec3 {
+    float x;
+    float y;
+    float z;
+
+    Vec3 operator+(const Vec3& other) const { return {x + other.x, y + other.y, z + other.z}; }
+    Vec3 operator-(const Vec3& other) const { return {x - other.x, y - other.y, z - other.z}; }
+    Vec3 operator*(float value) const { return {x * value, y * value, z * value}; }
+};
+
+Vec3 cross(const Vec3& a, const Vec3& b)
+{
+    return {
+        a.y * b.z - a.z * b.y,
+        a.z * b.x - a.x * b.z,
+        a.x * b.y - a.y * b.x,
+    };
+}
+
+float dot(const Vec3& a, const Vec3& b)
+{
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+Vec3 normalize(const Vec3& value)
+{
+    const float length = std::sqrt(std::max(dot(value, value), 0.000001f));
+    return value * (1.0f / length);
+}
+
+struct Color {
+    int r;
+    int g;
+    int b;
+};
+
+Color scaleColor(Color color, float scale)
+{
+    return {
+        std::clamp(static_cast<int>(color.r * scale), 0, 255),
+        std::clamp(static_cast<int>(color.g * scale), 0, 255),
+        std::clamp(static_cast<int>(color.b * scale), 0, 255),
+    };
+}
+
+Color mixColor(Color a, Color b, float amount)
+{
+    amount = std::clamp(amount, 0.0f, 1.0f);
+    return {
+        static_cast<int>(a.r + (b.r - a.r) * amount),
+        static_cast<int>(a.g + (b.g - a.g) * amount),
+        static_cast<int>(a.b + (b.b - a.b) * amount),
+    };
+}
+
+std::uint32_t packColor(Color color)
+{
+    return 0xff000000u
+        | (static_cast<std::uint32_t>(std::clamp(color.r, 0, 255)) << 16)
+        | (static_cast<std::uint32_t>(std::clamp(color.g, 0, 255)) << 8)
+        | static_cast<std::uint32_t>(std::clamp(color.b, 0, 255));
+}
+
+class Surface {
+public:
+    Surface()
+        : pixels(kWidth * kHeight),
+          depth(kWidth * kHeight)
+    {
+    }
+
+    void clear(Color color)
+    {
+        std::fill(pixels.begin(), pixels.end(), packColor(color));
+        std::fill(depth.begin(), depth.end(), std::numeric_limits<float>::infinity());
+    }
+
+    void blendPixel(int x, int y, Color color, float alpha)
+    {
+        if (x < 0 || x >= kWidth || y < 0 || y >= kHeight) {
+            return;
+        }
+
+        const std::size_t index = static_cast<std::size_t>(y) * kWidth + x;
+        const std::uint32_t old = pixels[index];
+        const Color background {
+            static_cast<int>((old >> 16) & 0xff),
+            static_cast<int>((old >> 8) & 0xff),
+            static_cast<int>(old & 0xff),
+        };
+        pixels[index] = packColor(mixColor(background, color, alpha));
+    }
+
+    void fillRect(int x, int y, int width, int height, Color color, float alpha = 1.0f)
+    {
+        const int left   = std::max(0, x);
+        const int top    = std::max(0, y);
+        const int right  = std::min(kWidth, x + width);
+        const int bottom = std::min(kHeight, y + height);
+
+        for (int py = top; py < bottom; ++py) {
+            for (int px = left; px < right; ++px) {
+                blendPixel(px, py, color, alpha);
+            }
+        }
+    }
+
+    std::vector<std::uint32_t> pixels;
+    std::vector<float>         depth;
+};
+
+struct Projected {
+    float x;
+    float y;
+    float inverseDepth;
+    bool  valid;
+};
+
+Projected project(const Vec3& point)
+{
+    if (point.z <= kNearPlane) {
+        return {0.0f, 0.0f, 0.0f, false};
+    }
+
+    const float inverseDepth = 1.0f / point.z;
+    return {
+        kWidth * 0.5f + point.x * kFocalLength * inverseDepth,
+        kHeight * 0.5f - (point.y - kCameraY) * kFocalLength * inverseDepth,
+        inverseDepth,
+        true,
+    };
+}
+
+float edge(float ax, float ay, float bx, float by, float px, float py)
+{
+    return (px - ax) * (by - ay) - (py - ay) * (bx - ax);
+}
+
+Color applyFog(Color color, float z)
+{
+    const float visibility = std::clamp((kFarPlane - z) / (kFarPlane - kFogNear), 0.0f, 1.0f);
+    return scaleColor(color, visibility);
+}
+
+void rasterTriangle(Surface& surface, const Vec3& a, const Vec3& b, const Vec3& c, Color color,
+    bool fog = true, float alpha = 1.0f)
+{
+    const Projected p0 = project(a);
+    const Projected p1 = project(b);
+    const Projected p2 = project(c);
+    if (!p0.valid || !p1.valid || !p2.valid) {
+        return;
+    }
+
+    const float area = edge(p0.x, p0.y, p1.x, p1.y, p2.x, p2.y);
+    if (std::abs(area) < 0.001f) {
+        return;
+    }
+
+    const int minX = std::max(0, static_cast<int>(std::floor(std::min({p0.x, p1.x, p2.x}))));
+    const int maxX = std::min(kWidth - 1, static_cast<int>(std::ceil(std::max({p0.x, p1.x, p2.x}))));
+    const int minY = std::max(0, static_cast<int>(std::floor(std::min({p0.y, p1.y, p2.y}))));
+    const int maxY = std::min(kHeight - 1, static_cast<int>(std::ceil(std::max({p0.y, p1.y, p2.y}))));
+    const float inverseArea = 1.0f / area;
+
+    for (int y = minY; y <= maxY; ++y) {
+        for (int x = minX; x <= maxX; ++x) {
+            const float px = x + 0.5f;
+            const float py = y + 0.5f;
+            const float w0 = edge(p1.x, p1.y, p2.x, p2.y, px, py) * inverseArea;
+            const float w1 = edge(p2.x, p2.y, p0.x, p0.y, px, py) * inverseArea;
+            const float w2 = 1.0f - w0 - w1;
+
+            if (w0 < 0.0f || w1 < 0.0f || w2 < 0.0f) {
+                continue;
+            }
+
+            const float inverseDepth =
+                w0 * p0.inverseDepth + w1 * p1.inverseDepth + w2 * p2.inverseDepth;
+            if (inverseDepth <= 0.0f) {
+                continue;
+            }
+
+            const float z = 1.0f / inverseDepth;
+            const std::size_t index = static_cast<std::size_t>(y) * kWidth + x;
+            if (z >= surface.depth[index]) {
+                continue;
+            }
+
+            const Color shaded = fog ? applyFog(color, z) : color;
+            if (alpha >= 0.999f) {
+                surface.pixels[index] = packColor(shaded);
+            } else {
+                surface.blendPixel(x, y, shaded, alpha);
+            }
+            surface.depth[index] = z;
+        }
+    }
+}
+
+void rasterLine(Surface& surface, const Vec3& a, const Vec3& b, Color color, int width = 1)
+{
+    const Projected p0 = project(a);
+    const Projected p1 = project(b);
+    if (!p0.valid || !p1.valid) {
+        return;
+    }
+
+    const float dx = p1.x - p0.x;
+    const float dy = p1.y - p0.y;
+    const int steps = std::max(1, static_cast<int>(std::ceil(std::max(std::abs(dx), std::abs(dy)))));
+
+    for (int i = 0; i <= steps; ++i) {
+        const float t = static_cast<float>(i) / steps;
+        const int x = static_cast<int>(std::round(p0.x + dx * t));
+        const int y = static_cast<int>(std::round(p0.y + dy * t));
+        const float inverseDepth = p0.inverseDepth + (p1.inverseDepth - p0.inverseDepth) * t;
+        const float z = 0.997f / std::max(inverseDepth, 0.00001f);
+        const Color shaded = applyFog(color, z);
+
+        for (int oy = -width / 2; oy <= width / 2; ++oy) {
+            for (int ox = -width / 2; ox <= width / 2; ++ox) {
+                const int px = x + ox;
+                const int py = y + oy;
+                if (px < 0 || px >= kWidth || py < 0 || py >= kHeight) {
+                    continue;
+                }
+                const std::size_t index = static_cast<std::size_t>(py) * kWidth + px;
+                if (z < surface.depth[index]) {
+                    surface.depth[index] = z;
+                    surface.pixels[index] = packColor(shaded);
+                }
+            }
+        }
+    }
+}
+
+Vec3 curveCenter(float z)
+{
+    const float distance = std::max(0.0f, z - 6.0f);
+    return {0.0f, -(distance * distance) / 20.0f, z};
+}
+
+std::array<std::uint8_t, 7> glyph(char character)
+{
+    switch (character) {
+    case 'A': return {14, 17, 17, 31, 17, 17, 17};
+    case 'B': return {30, 17, 17, 30, 17, 17, 30};
+    case 'C': return {14, 17, 16, 16, 16, 17, 14};
+    case 'D': return {30, 17, 17, 17, 17, 17, 30};
+    case 'E': return {31, 16, 16, 30, 16, 16, 31};
+    case 'F': return {31, 16, 16, 30, 16, 16, 16};
+    case 'G': return {14, 17, 16, 23, 17, 17, 15};
+    case 'H': return {17, 17, 17, 31, 17, 17, 17};
+    case 'I': return {14, 4, 4, 4, 4, 4, 14};
+    case 'J': return {1, 1, 1, 1, 17, 17, 14};
+    case 'K': return {17, 18, 20, 24, 20, 18, 17};
+    case 'L': return {16, 16, 16, 16, 16, 16, 31};
+    case 'M': return {17, 27, 21, 21, 17, 17, 17};
+    case 'N': return {17, 25, 21, 19, 17, 17, 17};
+    case 'O': return {14, 17, 17, 17, 17, 17, 14};
+    case 'P': return {30, 17, 17, 30, 16, 16, 16};
+    case 'Q': return {14, 17, 17, 17, 21, 18, 13};
+    case 'R': return {30, 17, 17, 30, 20, 18, 17};
+    case 'S': return {15, 16, 16, 14, 1, 1, 30};
+    case 'T': return {31, 4, 4, 4, 4, 4, 4};
+    case 'U': return {17, 17, 17, 17, 17, 17, 14};
+    case 'V': return {17, 17, 17, 17, 17, 10, 4};
+    case 'W': return {17, 17, 17, 21, 21, 21, 10};
+    case 'X': return {17, 17, 10, 4, 10, 17, 17};
+    case 'Y': return {17, 17, 10, 4, 4, 4, 4};
+    case 'Z': return {31, 1, 2, 4, 8, 16, 31};
+    case '0': return {14, 17, 19, 21, 25, 17, 14};
+    case '1': return {4, 12, 4, 4, 4, 4, 14};
+    case '2': return {14, 17, 1, 2, 4, 8, 31};
+    case '3': return {30, 1, 1, 14, 1, 1, 30};
+    case '4': return {2, 6, 10, 18, 31, 2, 2};
+    case '5': return {31, 16, 16, 30, 1, 1, 30};
+    case '6': return {14, 16, 16, 30, 17, 17, 14};
+    case '7': return {31, 1, 2, 4, 8, 8, 8};
+    case '8': return {14, 17, 17, 14, 17, 17, 14};
+    case '9': return {14, 17, 17, 15, 1, 1, 14};
+    case '-': return {0, 0, 0, 31, 0, 0, 0};
+    case '/': return {1, 1, 2, 4, 8, 16, 16};
+    case '[': return {14, 8, 8, 8, 8, 8, 14};
+    case ']': return {14, 2, 2, 2, 2, 2, 14};
+    case ':': return {0, 4, 4, 0, 4, 4, 0};
+    default:  return {0, 0, 0, 0, 0, 0, 0};
+    }
+}
+
+void drawText(Surface& surface, int x, int y, const std::string& text, int scale, Color color,
+    bool shadow = true)
+{
+    auto drawGlyph = [&](int glyphX, int glyphY, char character, Color glyphColor) {
+        const auto rows = glyph(character);
+        for (int row = 0; row < 7; ++row) {
+            for (int column = 0; column < 5; ++column) {
+                if ((rows[row] & (1u << (4 - column))) != 0) {
+                    surface.fillRect(
+                        glyphX + column * scale, glyphY + row * scale, scale, scale, glyphColor);
+                }
+            }
+        }
+    };
+
+    int cursor = x;
+    for (char character : text) {
+        if (shadow) {
+            drawGlyph(cursor + scale, y + scale, character, {0, 0, 0});
+        }
+        drawGlyph(cursor, y, character, color);
+        cursor += 6 * scale;
+    }
+}
+
+class Random {
+public:
+    explicit Random(std::uint32_t seed)
+        : state(seed)
+    {
+    }
+
+    std::uint32_t next()
+    {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        return state;
+    }
+
+    int range(int limit) { return static_cast<int>(next() % static_cast<std::uint32_t>(limit)); }
+
+private:
+    std::uint32_t state;
+};
+
+struct Obstacle {
+    float z;
+    int   track;
+    Color color;
+    float tangentSize;
+    float radialSize;
+    float depthSize;
+    float speedScale;
+};
+
+constexpr std::array<Color, 13> kObstacleColors {{
+    {255, 153, 204},
+    {153, 255, 204},
+    {153, 204, 255},
+    {191, 191, 191},
+    {128, 128, 128},
+    {64, 64, 64},
+    {255, 40, 40},
+    {40, 255, 80},
+    {255, 128, 20},
+    {255, 45, 45},
+    {40, 255, 90},
+    {255, 150, 20},
+    {30, 235, 255},
+}};
+
+float wrapAngle(float angle)
+{
+    while (angle > kPi) angle -= 2.0f * kPi;
+    while (angle < -kPi) angle += 2.0f * kPi;
+    return angle;
+}
+
+class Game {
+public:
+    Game()
+        : random(0x58454745u)
+    {
+        reset();
+    }
+
+    void reset()
+    {
+        obstacles.clear();
+        elapsed         = 0.0f;
+        score           = 0.0f;
+        rotation        = 0.0f;
+        angularVelocity = 0.0f;
+        spawnTimer      = 0.35f;
+        invincible      = 0.0f;
+        lives           = 3;
+        stage           = 0;
+        paused          = false;
+        gameOver        = false;
+    }
+
+    void togglePause()
+    {
+        if (!gameOver) paused = !paused;
+    }
+
+    void update(float deltaTime, bool turnLeft, bool turnRight)
+    {
+        if (paused || gameOver) {
+            return;
+        }
+
+        elapsed += deltaTime;
+        stage = static_cast<int>(elapsed / 18.0f) % 8;
+        const float speed = 2.55f + 0.16f * static_cast<int>(elapsed / 18.0f);
+        score += speed * deltaTime * 10.0f;
+        invincible = std::max(0.0f, invincible - deltaTime);
+
+        const float targetVelocity = (turnRight ? 1.9f : 0.0f) - (turnLeft ? 1.9f : 0.0f);
+        angularVelocity += (targetVelocity - angularVelocity) * std::min(1.0f, deltaTime * 8.0f);
+        if (!turnLeft && !turnRight) {
+            angularVelocity *= std::pow(0.12f, deltaTime);
+        }
+        rotation = wrapAngle(rotation + angularVelocity * deltaTime);
+
+        for (Obstacle& obstacle : obstacles) {
+            obstacle.z -= speed * obstacle.speedScale * deltaTime;
+        }
+
+        checkCollisions();
+        obstacles.erase(std::remove_if(obstacles.begin(), obstacles.end(),
+                            [](const Obstacle& obstacle) { return obstacle.z < 0.22f; }),
+            obstacles.end());
+
+        spawnTimer -= deltaTime;
+        if (spawnTimer <= 0.0f) {
+            spawnPattern();
+        }
+    }
+
+    void render(Surface& surface) const
+    {
+        surface.clear({2, 4, 10});
+        drawTube(surface);
+
+        for (const Obstacle& obstacle : obstacles) {
+            drawObstacle(surface, obstacle);
+        }
+
+        if (invincible <= 0.0f || (static_cast<int>(invincible * 12.0f) & 1) == 0) {
+            drawPlayer(surface);
+        }
+        drawHud(surface);
+
+        if (invincible > 0.8f) {
+            surface.fillRect(0, 0, kWidth, kHeight, {255, 215, 30}, 0.16f);
+        }
+
+        if (paused || gameOver) {
+            surface.fillRect(0, 0, kWidth, kHeight, {0, 0, 0}, 0.62f);
+            const std::string message = gameOver ? "GAME OVER" : "PAUSED";
+            const int scale = 5;
+            const int textWidth = static_cast<int>(message.size()) * 6 * scale;
+            drawText(surface, (kWidth - textWidth) / 2, 190, message, scale,
+                gameOver ? Color {255, 80, 70} : Color {255, 220, 70});
+            drawText(surface, 214, 242, gameOver ? "[R] RESTART" : "[P] RESUME", 2, {220, 235, 255});
+        }
+    }
+
+private:
+    void spawnOne(int track, int colorIndex, float tangentScale = 0.78f,
+        float radialScale = 0.72f, float depthScale = 0.86f, float speedScale = 1.0f,
+        float zOffset = 0.0f)
+    {
+        obstacles.push_back({
+            kFarPlane - 0.3f + zOffset,
+            track % kTracks,
+            kObstacleColors[colorIndex],
+            kTileSize * tangentScale,
+            kTileSize * radialScale,
+            kTileSize * depthScale,
+            speedScale,
+        });
+    }
+
+    void spawnPattern()
+    {
+        const int track = random.range(kTracks);
+
+        switch (stage) {
+        case 0:
+            spawnOne(track, random.range(3));
+            spawnTimer = 0.82f;
+            break;
+        case 1:
+            spawnOne(track, 6, 0.76f, 0.72f, 0.82f, 1.28f);
+            spawnTimer = 0.92f;
+            break;
+        case 2:
+            spawnOne(track, 3 + random.range(3), 0.82f, 1.18f, 0.92f);
+            spawnTimer = 1.15f;
+            break;
+        case 3:
+            spawnOne(track, 8, 0.82f, 1.75f, 0.88f);
+            spawnTimer = 1.25f;
+            break;
+        case 4:
+            spawnOne(track, random.range(3));
+            if (random.range(4) == 0) {
+                spawnOne((track + 3 + random.range(4)) % kTracks, 11, 0.78f, 1.55f, 0.86f);
+            }
+            spawnTimer = 0.74f;
+            break;
+        case 5: {
+            const int count = 4 + 2 * random.range(3);
+            for (int i = 0; i < count; ++i) {
+                spawnOne((track + i) % kTracks, 12);
+            }
+            spawnTimer = 1.55f;
+            break;
+        }
+        case 6:
+            spawnOne(track, random.range(3));
+            if (random.range(3) == 0) {
+                spawnOne((track + 1) % kTracks, 12, 0.75f, 0.75f, 0.82f, 1.0f, 0.32f);
+                spawnOne((track + 2) % kTracks, 12, 0.75f, 0.75f, 0.82f, 1.0f, 0.64f);
+            }
+            spawnTimer = 0.64f;
+            break;
+        default:
+            spawnOne(track, 9, 2.65f, 1.7f, 0.9f);
+            spawnOne((track + 5 + random.range(3)) % kTracks, 7, 0.76f, 0.76f, 0.82f, 1.2f, 0.5f);
+            spawnTimer = 1.42f;
+            break;
+        }
+    }
+
+    void checkCollisions()
+    {
+        if (invincible > 0.0f) {
+            return;
+        }
+
+        for (Obstacle& obstacle : obstacles) {
+            if (obstacle.z < 0.72f || obstacle.z > 1.36f) {
+                continue;
+            }
+
+            const float angle = kPlayerAngle + obstacle.track * kTrackAngle + rotation;
+            const float angularExtent = (obstacle.tangentSize / (2.0f * 0.72f)) + 0.12f;
+            if (std::abs(wrapAngle(angle - kPlayerAngle)) < angularExtent) {
+                obstacle.z = 0.15f;
+                invincible = 1.25f;
+                --lives;
+                if (lives <= 0) {
+                    gameOver = true;
+                }
+                break;
+            }
+        }
+    }
+
+    Vec3 tubePoint(int trackEdge, float z) const
+    {
+        const float angle =
+            kPlayerAngle - kTrackAngle * 0.5f + trackEdge * kTrackAngle + rotation;
+        const Vec3 center = curveCenter(z);
+        return {
+            center.x + std::cos(angle) * kTubeRadius,
+            center.y + std::sin(angle) * kTubeRadius,
+            z,
+        };
+    }
+
+    void drawTube(Surface& surface) const
+    {
+        const bool brightStage = (stage % 2) == 0;
+        const float brightness = brightStage ? 1.0f : 0.34f;
+
+        for (int row = 0; row < kTubeRows; ++row) {
+            const float z0 = 0.42f + row * kTileSize;
+            const float z1 = z0 + kTileSize;
+            for (int track = 0; track < kTracks; ++track) {
+                const Vec3 p00 = tubePoint(track, z0);
+                const Vec3 p10 = tubePoint(track + 1, z0);
+                const Vec3 p11 = tubePoint(track + 1, z1);
+                const Vec3 p01 = tubePoint(track, z1);
+                const float checker = ((track + row) & 1) ? 0.93f : 1.0f;
+                const Color tile = scaleColor({224, 234, 244}, brightness * checker);
+                rasterTriangle(surface, p00, p10, p11, tile);
+                rasterTriangle(surface, p00, p11, p01, tile);
+            }
+        }
+
+        const Color grid = brightStage ? Color {25, 42, 58} : Color {4, 8, 13};
+        for (int row = 0; row <= kTubeRows; ++row) {
+            const float z = 0.42f + row * kTileSize;
+            for (int track = 0; track < kTracks; ++track) {
+                rasterLine(surface, tubePoint(track, z), tubePoint(track + 1, z), grid);
+            }
+        }
+        for (int row = 0; row < kTubeRows; ++row) {
+            const float z0 = 0.42f + row * kTileSize;
+            const float z1 = z0 + kTileSize;
+            for (int track = 0; track < kTracks; ++track) {
+                rasterLine(surface, tubePoint(track, z0), tubePoint(track, z1), grid);
+            }
+        }
+    }
+
+    void drawBox(Surface& surface, Vec3 center, const Vec3& tangent, const Vec3& radial,
+        float tangentSize, float radialSize, float depthSize, Color color, float alpha = 1.0f) const
+    {
+        const Vec3 t = tangent * (tangentSize * 0.5f);
+        const Vec3 r = radial * (radialSize * 0.5f);
+        const Vec3 d {0.0f, 0.0f, depthSize * 0.5f};
+        const std::array<Vec3, 8> vertices {{
+            center - t - r - d,
+            center + t - r - d,
+            center + t + r - d,
+            center - t + r - d,
+            center - t - r + d,
+            center + t - r + d,
+            center + t + r + d,
+            center - t + r + d,
+        }};
+        constexpr std::array<std::array<int, 4>, 6> faces {{
+            {{0, 1, 2, 3}},
+            {{5, 4, 7, 6}},
+            {{4, 0, 3, 7}},
+            {{1, 5, 6, 2}},
+            {{3, 2, 6, 7}},
+            {{4, 5, 1, 0}},
+        }};
+        const Vec3 light = normalize({-0.35f, 0.65f, -0.65f});
+
+        for (const auto& face : faces) {
+            const Vec3 normal = normalize(cross(
+                vertices[face[1]] - vertices[face[0]], vertices[face[2]] - vertices[face[0]]));
+            const float lightAmount = 0.42f + 0.58f * std::abs(dot(normal, light));
+            const Color faceColor = scaleColor(color, lightAmount);
+            rasterTriangle(surface, vertices[face[0]], vertices[face[1]], vertices[face[2]],
+                faceColor, true, alpha);
+            rasterTriangle(surface, vertices[face[0]], vertices[face[2]], vertices[face[3]],
+                faceColor, true, alpha);
+        }
+
+        const Color edgeColor = scaleColor(color, 0.24f);
+        constexpr std::array<std::array<int, 2>, 12> edges {{
+            {{0, 1}}, {{1, 2}}, {{2, 3}}, {{3, 0}},
+            {{4, 5}}, {{5, 6}}, {{6, 7}}, {{7, 4}},
+            {{0, 4}}, {{1, 5}}, {{2, 6}}, {{3, 7}},
+        }};
+        for (const auto& edge : edges) {
+            rasterLine(surface, vertices[edge[0]], vertices[edge[1]], edgeColor);
+        }
+    }
+
+    void drawObstacle(Surface& surface, const Obstacle& obstacle) const
+    {
+        const float angle = kPlayerAngle + obstacle.track * kTrackAngle + rotation;
+        const Vec3 radial {std::cos(angle), std::sin(angle), 0.0f};
+        const Vec3 tangent {-std::sin(angle), std::cos(angle), 0.0f};
+        Vec3 center = curveCenter(obstacle.z);
+        center = center + radial * 0.72f;
+        drawBox(surface, center, tangent, radial, obstacle.tangentSize, obstacle.radialSize,
+            obstacle.depthSize, obstacle.color);
+    }
+
+    void drawPlayer(Surface& surface) const
+    {
+        const Vec3 radial {0.0f, -1.0f, 0.0f};
+        const Vec3 tangent {1.0f, 0.0f, 0.0f};
+        const Vec3 center {0.0f, -0.80f, 0.72f};
+        drawBox(surface, center, tangent, radial, 0.20f, 0.20f, 0.20f,
+            {255, 226, 35}, 0.94f);
+    }
+
+    void drawHud(Surface& surface) const
+    {
+        surface.fillRect(14, 14, 214, 62, {3, 8, 16}, 0.72f);
+        surface.fillRect(14, 14, 214, 2, {70, 225, 255}, 0.88f);
+        drawText(surface, 26, 24, "CUBE RUNNER", 2, {115, 235, 255});
+        drawText(surface, 26, 48, "SCORE " + std::to_string(static_cast<int>(score)), 2,
+            {245, 248, 255});
+
+        const std::string status =
+            "LIVES " + std::to_string(lives) + "   STAGE " + std::to_string(stage + 1);
+        const int statusWidth = static_cast<int>(status.size()) * 12;
+        drawText(surface, kWidth - statusWidth - 18, 24, status, 2, {255, 225, 70});
+
+        surface.fillRect(0, kHeight - 31, kWidth, 31, {2, 5, 11}, 0.72f);
+        drawText(surface, 88, kHeight - 22, "[A/D] STEER   [P] PAUSE   [R] RESTART", 1,
+            {190, 220, 240}, false);
+    }
+
+    Random                random;
+    std::vector<Obstacle> obstacles;
+    float                 elapsed {0.0f};
+    float                 score {0.0f};
+    float                 rotation {0.0f};
+    float                 angularVelocity {0.0f};
+    float                 spawnTimer {0.0f};
+    float                 invincible {0.0f};
+    int                   lives {3};
+    int                   stage {0};
+    bool                  paused {false};
+    bool                  gameOver {false};
+};
+
+bool savePpm(const Surface& surface, const std::string& path)
+{
+    std::ofstream file(path, std::ios::binary);
+    if (!file) {
+        return false;
+    }
+
+    file << "P6\n" << kWidth << ' ' << kHeight << "\n255\n";
+    for (std::uint32_t pixel : surface.pixels) {
+        const std::array<char, 3> rgb {{
+            static_cast<char>((pixel >> 16) & 0xff),
+            static_cast<char>((pixel >> 8) & 0xff),
+            static_cast<char>(pixel & 0xff),
+        }};
+        file.write(rgb.data(), rgb.size());
+    }
+    return static_cast<bool>(file);
+}
+
+} // namespace cube_runner
+
+#ifdef CUBE_RUNNER_HEADLESS
+
+#include <cstdlib>
+#include <iostream>
+
+int main(int argc, char** argv)
+{
+    const std::string outputPath = argc > 1 ? argv[1] : "cube_runner.ppm";
+    const int frameCount = argc > 2 ? std::max(1, std::atoi(argv[2])) : 360;
+
+    cube_runner::Game game;
+    for (int frame = 0; frame < frameCount; ++frame) {
+        const bool turnLeft  = (frame > 160 && frame < 205);
+        const bool turnRight = (frame > 275 && frame < 330);
+        game.update(1.0f / 60.0f, turnLeft, turnRight);
+    }
+
+    cube_runner::Surface surface;
+    game.render(surface);
+    if (!cube_runner::savePpm(surface, outputPath)) {
+        std::cerr << "Failed to save " << outputPath << '\n';
+        return 1;
+    }
+
+    std::cout << "Saved " << outputPath << " (" << cube_runner::kWidth << 'x'
+              << cube_runner::kHeight << ")\n";
+    return 0;
+}
+
+#else
+
+int main()
+{
+    using namespace ege;
+    using namespace cube_runner;
+
+    initgraph(kWidth, kHeight, INIT_RENDERMANUAL);
+    setcaption("XEGE - Cube Runner");
+    setrendermode(RENDER_MANUAL);
+
+    PIMAGE frameImage = newimage(kWidth, kHeight);
+    Surface surface;
+    Game game;
+
+    for (; is_run(); delay_fps(60)) {
+        if (keypress(key_esc)) {
+            break;
+        }
+        if (keypress(key_P)) {
+            game.togglePause();
+        }
+        if (keypress(key_R)) {
+            game.reset();
+        }
+
+        const bool turnLeft  = keystate(key_left) || keystate(key_A);
+        const bool turnRight = keystate(key_right) || keystate(key_D);
+        game.update(1.0f / 60.0f, turnLeft, turnRight);
+        game.render(surface);
+
+        color_t* destination = getbuffer(frameImage);
+        std::copy(surface.pixels.begin(), surface.pixels.end(), destination);
+        putimage(0, 0, frameImage);
+    }
+
+    delimage(frameImage);
+    closegraph();
+    return 0;
+}
+
+#endif

--- a/demo/game_cube_runner.cpp
+++ b/demo/game_cube_runner.cpp
@@ -9,39 +9,198 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
+#include <condition_variable>
 #include <cstdint>
+#include <cstdlib>
 #include <fstream>
+#include <functional>
+#include <iomanip>
+#include <iostream>
 #include <limits>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
+
+// Total render threads, including the main thread. Set to 1 to disable parallel rendering.
+#ifndef CUBE_RUNNER_MAX_RENDER_THREADS
+#define CUBE_RUNNER_MAX_RENDER_THREADS 4
+#endif
 
 namespace cube_runner {
 
-constexpr int   kWidth       = 640;
-constexpr int   kHeight      = 480;
-constexpr int   kTracks      = 12;
-constexpr int   kTubeRows    = 24;
-constexpr int   kStageCount  = 8;
-constexpr float kPi          = 3.14159265358979323846f;
-constexpr float kTrackAngle  = 2.0f * kPi / kTracks;
-const     float kTileSize    = 2.0f * std::sin(kPi / kTracks);
-constexpr float kTubeRadius  = 1.0f;
-constexpr float kNearPlane   = 0.18f;
-const     float kFarPlane    = kTileSize * kTubeRows;
-const     float kFogNear     = kFarPlane * 0.25f;
-constexpr float kCameraY     = -0.5f;
-constexpr float kPlayerAngle = -kPi * 0.5f;
-const     float kFocalLength = (kHeight * 0.5f) / std::tan(75.0f * kPi / 360.0f);
+constexpr int   kDefaultWidth        = 1280;
+constexpr int   kDefaultHeight       = 720;
+constexpr int   kTracks              = 12;
+constexpr int   kTubeRows            = 24;
+constexpr int   kStageCount          = 8;
+constexpr float kPi                  = 3.14159265358979323846f;
+constexpr float kTrackAngle          = 2.0f * kPi / kTracks;
+const     float kTileSize            = 2.0f * std::sin(kPi / kTracks);
+constexpr float kTubeRadius          = 1.0f;
+constexpr float kNearPlane           = 0.18f;
+const     float kFarPlane            = kTileSize * kTubeRows;
+const     float kFogNear             = kFarPlane * 0.25f;
+constexpr float kCameraY             = -0.5f;
+constexpr float kPlayerAngle         = -kPi * 0.5f;
+constexpr float kVerticalFieldOfView = 75.0f;
 // The browser game advances 0.14 world units per 60 Hz frame and adds
 // 0.02 units per frame after each complete eight-stage level.
-constexpr float kReferenceFps   = 60.0f;
-constexpr float kBaseSpeed      = 0.14f * kReferenceFps;
-constexpr float kLevelSpeedStep = 0.02f * kReferenceFps;
-constexpr float kStageDuration  = 30.0f;
-constexpr float kTubeStart      = 0.42f;
-constexpr float kKeyboardTurnSpeed = kTrackAngle * 8.0f;
+constexpr float kReferenceFps         = 60.0f;
+constexpr float kBaseSpeed            = 0.14f * kReferenceFps;
+constexpr float kLevelSpeedStep       = 0.02f * kReferenceFps;
+constexpr float kStageDuration        = 30.0f;
+constexpr float kTubeStart            = 0.42f;
+constexpr float kKeyboardTurnSpeed    = kTrackAngle * 8.0f;
 constexpr float kMouseDragSensitivity = kTrackAngle / 56.0f;
+
+static_assert(CUBE_RUNNER_MAX_RENDER_THREADS >= 1,
+    "CUBE_RUNNER_MAX_RENDER_THREADS must be at least one");
+
+thread_local int gRenderBandTop = 0;
+thread_local int gRenderBandBottom = std::numeric_limits<int>::max();
+
+class RenderBandScope {
+public:
+    RenderBandScope(int top, int bottom)
+        : previousTop(gRenderBandTop),
+          previousBottom(gRenderBandBottom)
+    {
+        gRenderBandTop = top;
+        gRenderBandBottom = bottom;
+    }
+
+    ~RenderBandScope()
+    {
+        gRenderBandTop = previousTop;
+        gRenderBandBottom = previousBottom;
+    }
+
+private:
+    int previousTop;
+    int previousBottom;
+};
+
+int chooseRenderThreadCount()
+{
+    const unsigned int hardwareThreads = std::thread::hardware_concurrency();
+    const int automaticCount = hardwareThreads == 0
+        ? 2 : (hardwareThreads >= 8 ? 4 : (hardwareThreads > 2 ? 2 : 1));
+    return std::max(1, std::min({automaticCount, CUBE_RUNNER_MAX_RENDER_THREADS, 4}));
+}
+
+class KeyPressLatch {
+public:
+    bool update(bool down, int pressCount)
+    {
+        const bool pressed = pressCount > 0 || (down && !wasDown);
+        wasDown = down;
+        return pressed;
+    }
+
+private:
+    bool wasDown {false};
+};
+
+class RenderExecutor {
+public:
+    RenderExecutor()
+        : totalThreads(chooseRenderThreadCount())
+    {
+        for (int workerIndex = 1; workerIndex < totalThreads; ++workerIndex) {
+            workers.emplace_back(&RenderExecutor::workerLoop, this, workerIndex);
+        }
+    }
+
+    ~RenderExecutor()
+    {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            stopping = true;
+            ++generation;
+        }
+        workReady.notify_all();
+        for (std::thread& worker : workers) {
+            worker.join();
+        }
+    }
+
+    int threadCount() const { return totalThreads; }
+
+    void execute(const std::function<void(int)>& task)
+    {
+        if (totalThreads == 1) {
+            task(0);
+            return;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            frameTask = task;
+            remainingWorkers = totalThreads - 1;
+            ++generation;
+        }
+        workReady.notify_all();
+        task(0);
+
+        std::unique_lock<std::mutex> lock(mutex);
+        frameFinished.wait(lock, [&] { return remainingWorkers == 0; });
+        frameTask = nullptr;
+    }
+
+private:
+    void workerLoop(int workerIndex)
+    {
+        std::size_t completedGeneration = 0;
+        for (;;) {
+            std::function<void(int)> task;
+            {
+                std::unique_lock<std::mutex> lock(mutex);
+                workReady.wait(lock, [&] {
+                    return stopping || generation != completedGeneration;
+                });
+                if (stopping) {
+                    return;
+                }
+                completedGeneration = generation;
+                task = frameTask;
+            }
+
+            task(workerIndex);
+
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                --remainingWorkers;
+                if (remainingWorkers == 0) {
+                    frameFinished.notify_one();
+                }
+            }
+        }
+    }
+
+    const int                     totalThreads;
+    std::vector<std::thread>      workers;
+    std::mutex                    mutex;
+    std::condition_variable       workReady;
+    std::condition_variable       frameFinished;
+    std::function<void(int)>      frameTask;
+    std::size_t                   generation {0};
+    int                           remainingWorkers {0};
+    bool                          stopping {false};
+};
+
+RenderExecutor& renderExecutor()
+{
+    static RenderExecutor executor;
+    return executor;
+}
+
+int renderThreadCount()
+{
+    return renderExecutor().threadCount();
+}
 
 struct Vec3 {
     float x;
@@ -108,25 +267,33 @@ std::uint32_t packColor(Color color)
 
 class Surface {
 public:
-    Surface()
-        : pixels(kWidth * kHeight),
-          depth(kWidth * kHeight)
+    explicit Surface(int width = kDefaultWidth, int height = kDefaultHeight)
+        : width(width),
+          height(height),
+          pixels(static_cast<std::size_t>(width) * height),
+          depth(static_cast<std::size_t>(width) * height)
     {
     }
 
     void clear(Color color)
     {
-        std::fill(pixels.begin(), pixels.end(), packColor(color));
-        std::fill(depth.begin(), depth.end(), std::numeric_limits<float>::infinity());
+        const int top = std::clamp(gRenderBandTop, 0, height);
+        const int bottom = std::clamp(gRenderBandBottom, top, height);
+        const std::size_t first = static_cast<std::size_t>(top) * width;
+        const std::size_t last = static_cast<std::size_t>(bottom) * width;
+        std::fill(pixels.begin() + first, pixels.begin() + last, packColor(color));
+        std::fill(depth.begin() + first, depth.begin() + last,
+            std::numeric_limits<float>::infinity());
     }
 
     void blendPixel(int x, int y, Color color, float alpha)
     {
-        if (x < 0 || x >= kWidth || y < 0 || y >= kHeight) {
+        if (x < 0 || x >= width || y < 0 || y >= height
+            || y < gRenderBandTop || y >= gRenderBandBottom) {
             return;
         }
 
-        const std::size_t index = static_cast<std::size_t>(y) * kWidth + x;
+        const std::size_t index = static_cast<std::size_t>(y) * width + x;
         const std::uint32_t old = pixels[index];
         const Color background {
             static_cast<int>((old >> 16) & 0xff),
@@ -136,12 +303,12 @@ public:
         pixels[index] = packColor(mixColor(background, color, alpha));
     }
 
-    void fillRect(int x, int y, int width, int height, Color color, float alpha = 1.0f)
+    void fillRect(int x, int y, int rectWidth, int rectHeight, Color color, float alpha = 1.0f)
     {
         const int left   = std::max(0, x);
-        const int top    = std::max(0, y);
-        const int right  = std::min(kWidth, x + width);
-        const int bottom = std::min(kHeight, y + height);
+        const int top    = std::max({0, y, gRenderBandTop});
+        const int right  = std::min(width, x + rectWidth);
+        const int bottom = std::min({height, y + rectHeight, gRenderBandBottom});
 
         for (int py = top; py < bottom; ++py) {
             for (int px = left; px < right; ++px) {
@@ -150,6 +317,8 @@ public:
         }
     }
 
+    int                        width;
+    int                        height;
     std::vector<std::uint32_t> pixels;
     std::vector<float>         depth;
 };
@@ -161,16 +330,18 @@ struct Projected {
     bool  valid;
 };
 
-Projected project(const Vec3& point)
+Projected project(const Surface& surface, const Vec3& point)
 {
     if (point.z <= kNearPlane) {
         return {0.0f, 0.0f, 0.0f, false};
     }
 
     const float inverseDepth = 1.0f / point.z;
+    const float focalLength = (surface.height * 0.5f)
+        / std::tan(kVerticalFieldOfView * kPi / 360.0f);
     return {
-        kWidth * 0.5f + point.x * kFocalLength * inverseDepth,
-        kHeight * 0.5f - (point.y - kCameraY) * kFocalLength * inverseDepth,
+        surface.width * 0.5f + point.x * focalLength * inverseDepth,
+        surface.height * 0.5f - (point.y - kCameraY) * focalLength * inverseDepth,
         inverseDepth,
         true,
     };
@@ -190,9 +361,9 @@ Color applyFog(Color color, float z)
 void rasterTriangle(Surface& surface, const Vec3& a, const Vec3& b, const Vec3& c, Color color,
     bool fog = true, float alpha = 1.0f)
 {
-    const Projected p0 = project(a);
-    const Projected p1 = project(b);
-    const Projected p2 = project(c);
+    const Projected p0 = project(surface, a);
+    const Projected p1 = project(surface, b);
+    const Projected p2 = project(surface, c);
     if (!p0.valid || !p1.valid || !p2.valid) {
         return;
     }
@@ -203,9 +374,12 @@ void rasterTriangle(Surface& surface, const Vec3& a, const Vec3& b, const Vec3& 
     }
 
     const int minX = std::max(0, static_cast<int>(std::floor(std::min({p0.x, p1.x, p2.x}))));
-    const int maxX = std::min(kWidth - 1, static_cast<int>(std::ceil(std::max({p0.x, p1.x, p2.x}))));
-    const int minY = std::max(0, static_cast<int>(std::floor(std::min({p0.y, p1.y, p2.y}))));
-    const int maxY = std::min(kHeight - 1, static_cast<int>(std::ceil(std::max({p0.y, p1.y, p2.y}))));
+    const int maxX = std::min(surface.width - 1,
+        static_cast<int>(std::ceil(std::max({p0.x, p1.x, p2.x}))));
+    const int minY = std::max({0, gRenderBandTop,
+        static_cast<int>(std::floor(std::min({p0.y, p1.y, p2.y})))});
+    const int maxY = std::min({surface.height - 1, gRenderBandBottom - 1,
+        static_cast<int>(std::ceil(std::max({p0.y, p1.y, p2.y})))});
     const float inverseArea = 1.0f / area;
 
     for (int y = minY; y <= maxY; ++y) {
@@ -227,7 +401,7 @@ void rasterTriangle(Surface& surface, const Vec3& a, const Vec3& b, const Vec3& 
             }
 
             const float z = 1.0f / inverseDepth;
-            const std::size_t index = static_cast<std::size_t>(y) * kWidth + x;
+            const std::size_t index = static_cast<std::size_t>(y) * surface.width + x;
             if (z >= surface.depth[index]) {
                 continue;
             }
@@ -243,39 +417,75 @@ void rasterTriangle(Surface& surface, const Vec3& a, const Vec3& b, const Vec3& 
     }
 }
 
-void rasterLine(Surface& surface, const Vec3& a, const Vec3& b, Color color, int width = 1)
+void rasterLine(Surface& surface, const Vec3& a, const Vec3& b, Color color)
 {
-    const Projected p0 = project(a);
-    const Projected p1 = project(b);
+    const Projected p0 = project(surface, a);
+    const Projected p1 = project(surface, b);
     if (!p0.valid || !p1.valid) {
         return;
     }
 
     const float dx = p1.x - p0.x;
     const float dy = p1.y - p0.y;
-    const int steps = std::max(1, static_cast<int>(std::ceil(std::max(std::abs(dx), std::abs(dy)))));
+    const bool xMajor = std::abs(dx) >= std::abs(dy);
+    const float lineWidth = std::clamp(surface.height / 480.0f, 1.35f, 2.0f);
+    const float halfWidth = lineWidth * 0.5f;
 
-    for (int i = 0; i <= steps; ++i) {
-        const float t = static_cast<float>(i) / steps;
-        const int x = static_cast<int>(std::round(p0.x + dx * t));
-        const int y = static_cast<int>(std::round(p0.y + dy * t));
+    auto drawSample = [&](int majorPixel, float minor, float t) {
         const float inverseDepth = p0.inverseDepth + (p1.inverseDepth - p0.inverseDepth) * t;
         const float z = 0.997f / std::max(inverseDepth, 0.00001f);
         const Color shaded = applyFog(color, z);
 
-        for (int oy = -width / 2; oy <= width / 2; ++oy) {
-            for (int ox = -width / 2; ox <= width / 2; ++ox) {
-                const int px = x + ox;
-                const int py = y + oy;
-                if (px < 0 || px >= kWidth || py < 0 || py >= kHeight) {
-                    continue;
-                }
-                const std::size_t index = static_cast<std::size_t>(py) * kWidth + px;
-                if (z < surface.depth[index]) {
-                    surface.depth[index] = z;
-                    surface.pixels[index] = packColor(shaded);
-                }
+        const int centerMinorPixel = static_cast<int>(std::floor(minor));
+        for (int offset = -1; offset <= 1; ++offset) {
+            const int minorPixel = centerMinorPixel + offset;
+            const float pixelCenter = minorPixel + 0.5f;
+            const float coverage = std::clamp(
+                halfWidth + 0.5f - std::abs(pixelCenter - minor), 0.0f, 1.0f);
+            if (coverage <= 0.0f) {
+                continue;
             }
+
+            const int x = xMajor ? majorPixel : minorPixel;
+            const int y = xMajor ? minorPixel : majorPixel;
+            if (x < 0 || x >= surface.width || y < 0 || y >= surface.height
+                || y < gRenderBandTop || y >= gRenderBandBottom) {
+                continue;
+            }
+
+            const std::size_t index = static_cast<std::size_t>(y) * surface.width + x;
+            if (z < surface.depth[index]) {
+                if (coverage >= 0.999f) {
+                    surface.pixels[index] = packColor(shaded);
+                } else {
+                    surface.blendPixel(x, y, shaded, coverage);
+                }
+                surface.depth[index] = z;
+            }
+        }
+    };
+
+    if (xMajor) {
+        const int first = std::max(0,
+            static_cast<int>(std::floor(std::min(p0.x, p1.x))));
+        const int last = std::min(surface.width - 1,
+            static_cast<int>(std::floor(std::max(p0.x, p1.x))));
+        for (int x = first; x <= last; ++x) {
+            const float sampleX = x + 0.5f;
+            const float t = std::clamp(
+                std::abs(dx) > 0.00001f ? (sampleX - p0.x) / dx : 0.0f, 0.0f, 1.0f);
+            drawSample(x, p0.y + dy * t, t);
+        }
+    } else {
+        const int first = std::max({0, gRenderBandTop,
+            static_cast<int>(std::floor(std::min(p0.y, p1.y)))});
+        const int last = std::min({surface.height - 1, gRenderBandBottom - 1,
+            static_cast<int>(std::floor(std::max(p0.y, p1.y)))});
+        for (int y = first; y <= last; ++y) {
+            const float sampleY = y + 0.5f;
+            const float t = std::clamp(
+                std::abs(dy) > 0.00001f ? (sampleY - p0.y) / dy : 0.0f, 0.0f, 1.0f);
+            drawSample(y, p0.x + dx * t, t);
         }
     }
 }
@@ -490,9 +700,24 @@ public:
     float rotationAngle() const { return rotation; }
     int currentStage() const { return stage; }
     int currentLevel() const { return level; }
+    int livesRemaining() const { return lives; }
+    bool isGameOver() const { return gameOver; }
     std::size_t obstacleCount() const { return obstacles.size(); }
 
-    void render(Surface& surface) const
+    void render(Surface& surface, float framesPerSecond = 0.0f) const
+    {
+        RenderExecutor& executor = renderExecutor();
+        const int threadCount = executor.threadCount();
+        executor.execute([&](int threadIndex) {
+            const int top = surface.height * threadIndex / threadCount;
+            const int bottom = surface.height * (threadIndex + 1) / threadCount;
+            RenderBandScope band(top, bottom);
+            renderBand(surface, framesPerSecond);
+        });
+    }
+
+private:
+    void renderBand(Surface& surface, float framesPerSecond) const
     {
         surface.clear({2, 4, 10});
         drawTube(surface);
@@ -504,24 +729,36 @@ public:
         if (invincible <= 0.0f || (static_cast<int>(invincible * 12.0f) & 1) == 0) {
             drawPlayer(surface);
         }
-        drawHud(surface);
+        drawHud(surface, framesPerSecond);
 
         if (invincible > 0.8f) {
-            surface.fillRect(0, 0, kWidth, kHeight, {255, 215, 30}, 0.16f);
+            surface.fillRect(0, 0, surface.width, surface.height, {255, 215, 30}, 0.16f);
         }
 
         if (paused || gameOver) {
-            surface.fillRect(0, 0, kWidth, kHeight, {0, 0, 0}, 0.62f);
+            surface.fillRect(0, 0, surface.width, surface.height, {0, 0, 0}, 0.62f);
             const std::string message = gameOver ? "GAME OVER" : "PAUSED";
-            const int scale = 5;
+            const int uiScale = hudScale(surface);
+            const int scale = 5 * uiScale;
             const int textWidth = static_cast<int>(message.size()) * 6 * scale;
-            drawText(surface, (kWidth - textWidth) / 2, 190, message, scale,
+            const int messageY = static_cast<int>(surface.height * 0.40f);
+            drawText(surface, (surface.width - textWidth) / 2, messageY, message, scale,
                 gameOver ? Color {255, 80, 70} : Color {255, 220, 70});
-            drawText(surface, 214, 242, gameOver ? "[R] RESTART" : "[P] RESUME", 2, {220, 235, 255});
+            const std::string action = gameOver ? "[R] RESTART" : "[P] RESUME";
+            const int actionScale = 2 * uiScale;
+            const int actionWidth = static_cast<int>(action.size()) * 6 * actionScale;
+            drawText(surface, (surface.width - actionWidth) / 2,
+                messageY + 52 * uiScale, action, actionScale, {220, 235, 255});
         }
     }
 
-private:
+    static int hudScale(const Surface& surface)
+    {
+        const float resolutionScale = std::min(
+            surface.width / 640.0f, surface.height / 480.0f);
+        return std::clamp(static_cast<int>(resolutionScale + 0.5f), 1, 3);
+    }
+
     void spawnOne(int track, int colorIndex, float tangentScale = 0.78f,
         float radialScale = 0.72f, float depthScale = 0.86f, float speedScale = 1.0f,
         float zOffset = 0.0f)
@@ -756,24 +993,39 @@ private:
             {255, 226, 35}, 0.94f);
     }
 
-    void drawHud(Surface& surface) const
+    void drawHud(Surface& surface, float framesPerSecond) const
     {
-        surface.fillRect(14, 14, 214, 62, {3, 8, 16}, 0.72f);
-        surface.fillRect(14, 14, 214, 2, {70, 225, 255}, 0.88f);
-        drawText(surface, 26, 24, "CUBE RUNNER", 2, {115, 235, 255});
-        drawText(surface, 26, 48, "SCORE " + std::to_string(static_cast<int>(score)), 2,
+        const int uiScale = hudScale(surface);
+        const int textScale = 2 * uiScale;
+        surface.fillRect(14 * uiScale, 14 * uiScale, 214 * uiScale, 62 * uiScale,
+            {3, 8, 16}, 0.72f);
+        surface.fillRect(14 * uiScale, 14 * uiScale, 214 * uiScale, 2 * uiScale,
+            {70, 225, 255}, 0.88f);
+        drawText(surface, 26 * uiScale, 24 * uiScale, "CUBE RUNNER", textScale,
+            {115, 235, 255});
+        drawText(surface, 26 * uiScale, 48 * uiScale,
+            "SCORE " + std::to_string(static_cast<int>(score)), textScale,
             {245, 248, 255});
 
         const std::string status =
             "LIVES " + std::to_string(lives) + "   STAGE " + std::to_string(stage + 1);
-        const int statusWidth = static_cast<int>(status.size()) * 12;
-        drawText(surface, kWidth - statusWidth - 18, 24, status, 2, {255, 225, 70});
+        const int statusWidth = static_cast<int>(status.size()) * 6 * textScale;
+        drawText(surface, surface.width - statusWidth - 18 * uiScale, 24 * uiScale,
+            status, textScale, {255, 225, 70});
 
-        surface.fillRect(0, kHeight - 31, kWidth, 31, {2, 5, 11}, 0.72f);
+        const std::string fps =
+            "FPS " + std::to_string(std::max(0, static_cast<int>(framesPerSecond + 0.5f)));
+        const int fpsWidth = static_cast<int>(fps.size()) * 6 * textScale;
+        drawText(surface, surface.width - fpsWidth - 18 * uiScale, 48 * uiScale,
+            fps, textScale, {115, 235, 255});
+
+        surface.fillRect(0, surface.height - 31 * uiScale, surface.width, 31 * uiScale,
+            {2, 5, 11}, 0.72f);
         const std::string controls =
             "[A/D] OR DRAG TO STEER   [P] PAUSE   [R] RESTART";
-        const int controlsWidth = static_cast<int>(controls.size()) * 6;
-        drawText(surface, (kWidth - controlsWidth) / 2, kHeight - 22, controls, 1,
+        const int controlsWidth = static_cast<int>(controls.size()) * 6 * uiScale;
+        drawText(surface, (surface.width - controlsWidth) / 2,
+            surface.height - 22 * uiScale, controls, uiScale,
             {190, 220, 240}, false);
     }
 
@@ -802,7 +1054,7 @@ bool savePpm(const Surface& surface, const std::string& path)
         return false;
     }
 
-    file << "P6\n" << kWidth << ' ' << kHeight << "\n255\n";
+    file << "P6\n" << surface.width << ' ' << surface.height << "\n255\n";
     for (std::uint32_t pixel : surface.pixels) {
         const std::array<char, 3> rgb {{
             static_cast<char>((pixel >> 16) & 0xff),
@@ -814,12 +1066,34 @@ bool savePpm(const Surface& surface, const std::string& path)
     return static_cast<bool>(file);
 }
 
+bool parseResolution(const std::string& text, int& width, int& height)
+{
+    const std::size_t separator = text.find_first_of("xX");
+    if (separator == std::string::npos) {
+        return false;
+    }
+
+    const std::string widthText = text.substr(0, separator);
+    const std::string heightText = text.substr(separator + 1);
+    char* widthEnd = nullptr;
+    char* heightEnd = nullptr;
+    const long parsedWidth = std::strtol(widthText.c_str(), &widthEnd, 10);
+    const long parsedHeight = std::strtol(heightText.c_str(), &heightEnd, 10);
+    if (widthEnd == widthText.c_str() || *widthEnd != '\0'
+        || heightEnd == heightText.c_str() || *heightEnd != '\0'
+        || parsedWidth < 640 || parsedWidth > 3840
+        || parsedHeight < 480 || parsedHeight > 2160) {
+        return false;
+    }
+
+    width = static_cast<int>(parsedWidth);
+    height = static_cast<int>(parsedHeight);
+    return true;
+}
+
 } // namespace cube_runner
 
 #ifdef CUBE_RUNNER_HEADLESS
-
-#include <cstdlib>
-#include <iostream>
 
 namespace {
 
@@ -832,9 +1106,11 @@ std::size_t changedPlayfieldPixels(
     const cube_runner::Surface& first, const cube_runner::Surface& second)
 {
     std::size_t changed = 0;
-    for (int y = 90; y < cube_runner::kHeight - 32; ++y) {
-        for (int x = 0; x < cube_runner::kWidth; ++x) {
-            const std::size_t index = static_cast<std::size_t>(y) * cube_runner::kWidth + x;
+    const int top = first.height * 90 / 480;
+    const int bottom = first.height - first.height * 32 / 480;
+    for (int y = top; y < bottom; ++y) {
+        for (int x = 0; x < first.width; ++x) {
+            const std::size_t index = static_cast<std::size_t>(y) * first.width + x;
             if (first.pixels[index] != second.pixels[index]) {
                 ++changed;
             }
@@ -868,6 +1144,47 @@ bool runSelfTest()
     require(changedPlayfieldPixels(before, after) > 500,
         "the tunnel playfield did not visibly move after one frame");
 
+    cube_runner::Surface lineSurface(640, 480);
+    lineSurface.clear({255, 255, 255});
+    cube_runner::rasterLine(lineSurface, {-0.5f, 0.0f, 2.0f}, {0.5f, 0.25f, 2.0f},
+        {0, 0, 0});
+    const std::size_t blendedLinePixels = static_cast<std::size_t>(std::count_if(
+        lineSurface.pixels.begin(), lineSurface.pixels.end(), [](std::uint32_t pixel) {
+            const std::uint32_t rgb = pixel & 0x00ffffffu;
+            return rgb != 0x00ffffffu && rgb != 0u;
+        }));
+    require(blendedLinePixels > 0,
+        "line rasterization did not produce antialiased edge coverage");
+
+    cube_runner::Surface fpsZero(800, 600);
+    cube_runner::Surface fpsSixty(800, 600);
+    movementGame.render(fpsZero, 0.0f);
+    movementGame.render(fpsSixty, 60.0f);
+    require(fpsZero.pixels != fpsSixty.pixels,
+        "the FPS value was not drawn into the HUD");
+
+    int parsedWidth = 0;
+    int parsedHeight = 0;
+    require(cube_runner::parseResolution("1280x720", parsedWidth, parsedHeight)
+            && parsedWidth == 1280 && parsedHeight == 720,
+        "a valid runtime resolution was rejected");
+    require(!cube_runner::parseResolution("1280-by-720", parsedWidth, parsedHeight),
+        "an invalid runtime resolution was accepted");
+    require(cube_runner::renderThreadCount() >= 1
+            && cube_runner::renderThreadCount() <= 4
+            && cube_runner::renderThreadCount() <= CUBE_RUNNER_MAX_RENDER_THREADS,
+        "the render worker count is outside the configured limit");
+
+    cube_runner::KeyPressLatch keyLatch;
+    require(keyLatch.update(false, 1),
+        "a short key press between frames was lost");
+    require(!keyLatch.update(false, 0),
+        "a consumed short key press was repeated");
+    require(keyLatch.update(true, 0) && !keyLatch.update(true, 0),
+        "a held key did not generate exactly one down edge");
+    require(!keyLatch.update(false, 0) && keyLatch.update(true, 0),
+        "a released key could not be pressed again");
+
     for (int frame = 1; frame < static_cast<int>(cube_runner::kReferenceFps); ++frame) {
         movementGame.update(deltaTime, false, false);
     }
@@ -894,6 +1211,26 @@ bool runSelfTest()
     require(nearlyEqual(movementGame.distance(), distanceBeforePause, 0.000001),
         "pausing did not stop forward movement");
 
+    cube_runner::Game resetGame(false);
+    for (int frame = 0; frame < 120; ++frame) {
+        resetGame.update(deltaTime, false, false);
+    }
+    resetGame.reset();
+    require(!resetGame.isGameOver() && resetGame.livesRemaining() == 3
+            && nearlyEqual(resetGame.distance(), 0.0, 0.000001)
+            && resetGame.obstacleCount() == 0,
+        "reset did not restore a fresh playable game");
+
+    cube_runner::Game gameOverResetGame;
+    for (int frame = 0; frame < 18000 && !gameOverResetGame.isGameOver(); ++frame) {
+        gameOverResetGame.update(deltaTime, false, false);
+    }
+    require(gameOverResetGame.isGameOver(),
+        "the deterministic collision scenario did not reach game over");
+    gameOverResetGame.reset();
+    require(!gameOverResetGame.isGameOver() && gameOverResetGame.livesRemaining() == 3,
+        "reset did not recover from game over");
+
     cube_runner::Game stageGame(false);
     const int framesPerStage = static_cast<int>(
         cube_runner::kStageDuration * cube_runner::kReferenceFps) + 1;
@@ -916,10 +1253,48 @@ bool runSelfTest()
         "level speed increase does not match the browser game");
 
     if (passed) {
-        std::cout << "Cube Runner self-test passed: speed, tunnel motion, spawning, pause, "
-                     "stages, and level progression\n";
+        std::cout << "Cube Runner self-test passed: motion, controls, antialiased lines, "
+                     "FPS HUD, runtime resolution, spawning, and progression\n";
     }
     return passed;
+}
+
+int runBenchmark(int width, int height, int frameCount)
+{
+    constexpr float deltaTime = 1.0f / cube_runner::kReferenceFps;
+    cube_runner::Game game(false);
+    cube_runner::Surface surface(width, height);
+
+    for (int frame = 0; frame < 30; ++frame) {
+        game.update(deltaTime, false, false);
+        game.render(surface);
+    }
+
+    const auto start = std::chrono::steady_clock::now();
+    for (int frame = 0; frame < frameCount; ++frame) {
+        const bool turnLeft = (frame % 240) >= 60 && (frame % 240) < 105;
+        const bool turnRight = (frame % 240) >= 155 && (frame % 240) < 210;
+        game.update(deltaTime, turnLeft, turnRight);
+        game.render(surface);
+    }
+    const auto finish = std::chrono::steady_clock::now();
+    const double seconds = std::chrono::duration<double>(finish - start).count();
+    const double framesPerSecond = frameCount / seconds;
+    const double millisecondsPerFrame = seconds * 1000.0 / frameCount;
+
+    std::uint64_t checksum = 0;
+    for (std::size_t index = 0; index < surface.pixels.size(); index += 997) {
+        checksum = checksum * 131u + surface.pixels[index];
+    }
+
+    std::cout << "BENCHMARK " << width << 'x' << height
+              << " frames=" << frameCount
+              << " threads=" << cube_runner::renderThreadCount()
+              << std::fixed << std::setprecision(2)
+              << " fps=" << framesPerSecond
+              << " ms/frame=" << millisecondsPerFrame
+              << " checksum=" << checksum << '\n';
+    return EXIT_SUCCESS;
 }
 
 } // namespace
@@ -929,9 +1304,32 @@ int main(int argc, char** argv)
     if (argc > 1 && std::string(argv[1]) == "--self-test") {
         return runSelfTest() ? EXIT_SUCCESS : EXIT_FAILURE;
     }
+    if (argc > 1 && std::string(argv[1]) == "--benchmark") {
+        int width = cube_runner::kDefaultWidth;
+        int height = cube_runner::kDefaultHeight;
+        if (argc < 3 || !cube_runner::parseResolution(argv[2], width, height)) {
+            std::cerr << "Usage: --benchmark WIDTHxHEIGHT [frames]\n";
+            return EXIT_FAILURE;
+        }
+        const int frameCount = argc > 3 ? std::max(1, std::atoi(argv[3])) : 240;
+        return runBenchmark(width, height, frameCount);
+    }
 
-    const std::string outputPath = argc > 1 ? argv[1] : "cube_runner.ppm";
-    const int frameCount = argc > 2 ? std::max(1, std::atoi(argv[2])) : 360;
+    int width = cube_runner::kDefaultWidth;
+    int height = cube_runner::kDefaultHeight;
+    int argumentOffset = 0;
+    if (argc > 1 && std::string(argv[1]) == "--render") {
+        if (argc < 3 || !cube_runner::parseResolution(argv[2], width, height)) {
+            std::cerr << "Usage: --render WIDTHxHEIGHT [output.ppm] [frames]\n";
+            return EXIT_FAILURE;
+        }
+        argumentOffset = 2;
+    }
+
+    const std::string outputPath = argc > argumentOffset + 1
+        ? argv[argumentOffset + 1] : "cube_runner.ppm";
+    const int frameCount = argc > argumentOffset + 2
+        ? std::max(1, std::atoi(argv[argumentOffset + 2])) : 360;
 
     cube_runner::Game game(false);
     for (int frame = 0; frame < frameCount; ++frame) {
@@ -940,43 +1338,83 @@ int main(int argc, char** argv)
         game.update(1.0f / 60.0f, turnLeft, turnRight);
     }
 
-    cube_runner::Surface surface;
+    cube_runner::Surface surface(width, height);
     game.render(surface);
     if (!cube_runner::savePpm(surface, outputPath)) {
         std::cerr << "Failed to save " << outputPath << '\n';
         return 1;
     }
 
-    std::cout << "Saved " << outputPath << " (" << cube_runner::kWidth << 'x'
-              << cube_runner::kHeight << ")\n";
+    std::cout << "Saved " << outputPath << " (" << surface.width << 'x'
+              << surface.height << ")\n";
     return 0;
 }
 
 #else
 
-int main()
+int main(int argc, char** argv)
 {
     using namespace ege;
     using namespace cube_runner;
 
-    initgraph(kWidth, kHeight, INIT_RENDERMANUAL);
+    int width = kDefaultWidth;
+    int height = kDefaultHeight;
+    int exitAfterFrames = 0;
+    for (int index = 1; index < argc; ++index) {
+        const std::string argument = argv[index];
+        if (argument == "--resolution" && index + 1 < argc) {
+            if (!parseResolution(argv[++index], width, height)) {
+                std::cerr << "Invalid resolution. Expected WIDTHxHEIGHT between 640x480 and 3840x2160.\n";
+                return EXIT_FAILURE;
+            }
+        } else if (argument == "--exit-after" && index + 1 < argc) {
+            exitAfterFrames = std::max(1, std::atoi(argv[++index]));
+        } else if (argument == "--help") {
+            std::cout << "Usage: game_cube_runner [--resolution WIDTHxHEIGHT]"
+                         " [--exit-after frames]\n";
+            return EXIT_SUCCESS;
+        } else {
+            std::cerr << "Unknown argument: " << argument << '\n';
+            return EXIT_FAILURE;
+        }
+    }
+
+    initgraph(width, height, INIT_ANIMATION);
     setcaption("XEGE - Cube Runner");
     setrendermode(RENDER_MANUAL);
 
-    PIMAGE frameImage = newimage(kWidth, kHeight);
-    Surface surface;
+    auto closeWindow = [] {
+        const HWND window = getHWnd();
+        SetCloseHandler(nullptr);
+        if (::IsWindow(window)) {
+            ::SendMessageW(window, WM_CLOSE, 0, 0);
+        }
+    };
+
+    PIMAGE frameImage = newimage(width, height);
+    if (frameImage == nullptr) {
+        std::cerr << "Failed to create the " << width << 'x' << height << " frame buffer.\n";
+        closeWindow();
+        return EXIT_FAILURE;
+    }
+    Surface surface(width, height);
     Game game;
     bool dragging = false;
     int lastMouseX = 0;
+    int renderedFrames = 0;
+    KeyPressLatch escapeKey;
+    KeyPressLatch pauseKey;
+    KeyPressLatch restartKey;
+    const float dragSensitivity = kMouseDragSensitivity * 640.0f / width;
 
-    for (; is_run(); delay_fps(60)) {
-        if (keypress(key_esc)) {
+    while (is_run()) {
+        if (escapeKey.update(keystate(key_esc), keypress(key_esc))) {
             break;
         }
-        if (keypress(key_P)) {
+        if (pauseKey.update(keystate(key_P), keypress(key_P))) {
             game.togglePause();
         }
-        if (keypress(key_R)) {
+        if (restartKey.update(keystate(key_R), keypress(key_R))) {
             game.reset();
         }
 
@@ -989,7 +1427,7 @@ int main()
             } else if (message.is_up() && message.is_left()) {
                 dragging = false;
             } else if (message.is_move() && dragging) {
-                dragRotation += (message.x - lastMouseX) * kMouseDragSensitivity;
+                dragRotation += (message.x - lastMouseX) * dragSensitivity;
                 lastMouseX = message.x;
             }
         }
@@ -1000,15 +1438,20 @@ int main()
         const bool turnLeft  = keystate(key_left) || keystate(key_A);
         const bool turnRight = keystate(key_right) || keystate(key_D);
         game.update(1.0f / 60.0f, turnLeft, turnRight, dragRotation);
-        game.render(surface);
+        game.render(surface, getfps());
 
         color_t* destination = getbuffer(frameImage);
         std::copy(surface.pixels.begin(), surface.pixels.end(), destination);
         putimage(0, 0, frameImage);
+        ++renderedFrames;
+        if (exitAfterFrames > 0 && renderedFrames >= exitAfterFrames) {
+            break;
+        }
+        delay_fps(60);
     }
 
     delimage(frameImage);
-    closegraph();
+    closeWindow();
     return 0;
 }
 

--- a/demo/game_cube_runner.cpp
+++ b/demo/game_cube_runner.cpp
@@ -29,6 +29,40 @@
 #define CUBE_RUNNER_MAX_RENDER_THREADS 4
 #endif
 
+// 文本本地化宏定义
+// 与其它 demo 一致: MSVC 编译器使用中文文案, 其它编译器使用英文文案.
+// 无头模式 (CUBE_RUNNER_HEADLESS) 始终使用英文, 因为内置位图字体仅支持 ASCII,
+// 且无头模式不依赖 EGE 字体系统.
+#if defined(_MSC_VER) && !defined(CUBE_RUNNER_HEADLESS)
+// MSVC 编译器使用中文文案
+#define TEXT_WINDOW_TITLE   "XEGE - 立方体跑酷"
+#define TEXT_HUD_TITLE      "立方体跑酷"
+#define TEXT_SCORE          "得分 "
+#define TEXT_LIVES          "生命 "
+#define TEXT_STAGE          "关卡 "
+#define TEXT_FPS            "帧率 "
+#define TEXT_CONTROLS       "[A/D] 或拖动转向   [P] 暂停   [R] 重新开始"
+#define TEXT_GAME_OVER      "游戏结束"
+#define TEXT_PAUSED         "已暂停"
+#define TEXT_ACTION_RESTART "[R] 重新开始"
+#define TEXT_ACTION_RESUME  "[P] 继续"
+#define TEXT_FONT_NAME      "宋体"
+#else
+// 非MSVC编译器 (或无头模式) 使用英文文案
+#define TEXT_WINDOW_TITLE   "XEGE - Cube Runner"
+#define TEXT_HUD_TITLE      "CUBE RUNNER"
+#define TEXT_SCORE          "SCORE "
+#define TEXT_LIVES          "LIVES "
+#define TEXT_STAGE          "STAGE "
+#define TEXT_FPS            "FPS "
+#define TEXT_CONTROLS       "[A/D] OR DRAG TO STEER   [P] PAUSE   [R] RESTART"
+#define TEXT_GAME_OVER      "GAME OVER"
+#define TEXT_PAUSED         "PAUSED"
+#define TEXT_ACTION_RESTART "[R] RESTART"
+#define TEXT_ACTION_RESUME  "[P] RESUME"
+#define TEXT_FONT_NAME      "Arial"
+#endif
+
 namespace cube_runner {
 
 constexpr int   kDefaultWidth        = 1280;
@@ -569,6 +603,64 @@ void drawText(Surface& surface, int x, int y, const std::string& text, int scale
     }
 }
 
+// The HUD text is rendered through a small canvas abstraction so the same
+// layout code can drive either the software bitmap font (headless builds, which
+// have no EGE font system) or EGE's native fonts (windowed builds, which need
+// CJK support). Both backends implement draw() and width() with matching
+// signatures; the Game class instantiates them via templates.
+
+// Bitmap font backend: renders into a software Surface using the 5x7 glyphs
+// above. Always available, used by the headless self-test / benchmark / PPM
+// paths so their output stays deterministic and free of system-font coupling.
+class BitmapTextCanvas {
+public:
+    explicit BitmapTextCanvas(Surface& surface) : surface(surface) {}
+
+    void draw(int x, int y, const std::string& text, int scale, Color color, bool shadow = true) const
+    {
+        drawText(surface, x, y, text, scale, color, shadow);
+    }
+
+    int width(const std::string& text, int scale) const
+    {
+        return static_cast<int>(text.size()) * 6 * scale;
+    }
+
+private:
+    Surface& surface;
+};
+
+#ifndef CUBE_RUNNER_HEADLESS
+// EGE native font backend: renders with the window's font system so the HUD can
+// display CJK glyphs. Used by the windowed build only. Font height tracks the
+// bitmap font's 7-pixel glyph rows so the HUD layout is preserved.
+class EgeTextCanvas {
+public:
+    EgeTextCanvas() = default;
+
+    void draw(int x, int y, const std::string& text, int scale, Color color, bool shadow = true) const
+    {
+        setfont(fontHeight(scale), 0, TEXT_FONT_NAME);
+        setbkmode(TRANSPARENT);
+        if (shadow) {
+            setcolor(EGERGB(0, 0, 0));
+            outtextxy(x + scale, y + scale, text.c_str());
+        }
+        setcolor(EGERGB(color.r, color.g, color.b));
+        outtextxy(x, y, text.c_str());
+    }
+
+    int width(const std::string& text, int scale) const
+    {
+        setfont(fontHeight(scale), 0, TEXT_FONT_NAME);
+        return textwidth(text.c_str());
+    }
+
+private:
+    static int fontHeight(int scale) { return std::max(7, 7 * scale); }
+};
+#endif // CUBE_RUNNER_HEADLESS
+
 class Random {
 public:
     explicit Random(std::uint32_t seed)
@@ -716,6 +808,16 @@ public:
         });
     }
 
+    // Draws the HUD and overlay text. Windowed builds pass an EgeTextCanvas (EGE
+    // native fonts, supports CJK); headless builds render text inside renderBand
+    // with the bitmap font instead, so they do not call this method.
+    template <typename Canvas>
+    void drawText(Canvas& canvas, const Surface& surface, float framesPerSecond) const
+    {
+        drawHudText(canvas, surface, framesPerSecond);
+        drawOverlayText(canvas, surface);
+    }
+
 private:
     void renderBand(Surface& surface, float framesPerSecond) const
     {
@@ -729,7 +831,7 @@ private:
         if (invincible <= 0.0f || (static_cast<int>(invincible * 12.0f) & 1) == 0) {
             drawPlayer(surface);
         }
-        drawHud(surface, framesPerSecond);
+        drawHudBackground(surface);
 
         if (invincible > 0.8f) {
             surface.fillRect(0, 0, surface.width, surface.height, {255, 215, 30}, 0.16f);
@@ -737,19 +839,18 @@ private:
 
         if (paused || gameOver) {
             surface.fillRect(0, 0, surface.width, surface.height, {0, 0, 0}, 0.62f);
-            const std::string message = gameOver ? "GAME OVER" : "PAUSED";
-            const int uiScale = hudScale(surface);
-            const int scale = 5 * uiScale;
-            const int textWidth = static_cast<int>(message.size()) * 6 * scale;
-            const int messageY = static_cast<int>(surface.height * 0.40f);
-            drawText(surface, (surface.width - textWidth) / 2, messageY, message, scale,
-                gameOver ? Color {255, 80, 70} : Color {255, 220, 70});
-            const std::string action = gameOver ? "[R] RESTART" : "[P] RESUME";
-            const int actionScale = 2 * uiScale;
-            const int actionWidth = static_cast<int>(action.size()) * 6 * actionScale;
-            drawText(surface, (surface.width - actionWidth) / 2,
-                messageY + 52 * uiScale, action, actionScale, {220, 235, 255});
         }
+
+#ifdef CUBE_RUNNER_HEADLESS
+        // Headless builds render text directly into the surface with the built-in
+        // bitmap font. Windowed builds defer text to drawText() so the HUD can use
+        // EGE's native fonts (and CJK glyphs) after the frame is blitted.
+        BitmapTextCanvas canvas(surface);
+        drawHudText(canvas, surface, framesPerSecond);
+        drawOverlayText(canvas, surface);
+#else
+        (void)framesPerSecond;
+#endif
     }
 
     static int hudScale(const Surface& surface)
@@ -840,9 +941,12 @@ private:
                 continue;
             }
 
-            const float angle = kPlayerAngle + obstacle.track * kTrackAngle + rotation;
+            // The player sits at a fixed kPlayerAngle, so only the obstacle's
+            // track offset and the current rotation determine the relative angle.
+            // (kPlayerAngle previously added and subtracted here cancelled out.)
+            const float relativeAngle = obstacle.track * kTrackAngle + rotation;
             const float angularExtent = (obstacle.tangentSize / (2.0f * 0.72f)) + 0.12f;
-            if (std::abs(wrapAngle(angle - kPlayerAngle)) < angularExtent) {
+            if (std::abs(wrapAngle(relativeAngle)) < angularExtent) {
                 obstacle.z = 0.15f;
                 invincible = 1.25f;
                 --lives;
@@ -993,40 +1097,66 @@ private:
             {255, 226, 35}, 0.94f);
     }
 
-    void drawHud(Surface& surface, float framesPerSecond) const
+    void drawHudBackground(Surface& surface) const
     {
         const int uiScale = hudScale(surface);
-        const int textScale = 2 * uiScale;
         surface.fillRect(14 * uiScale, 14 * uiScale, 214 * uiScale, 62 * uiScale,
             {3, 8, 16}, 0.72f);
         surface.fillRect(14 * uiScale, 14 * uiScale, 214 * uiScale, 2 * uiScale,
             {70, 225, 255}, 0.88f);
-        drawText(surface, 26 * uiScale, 24 * uiScale, "CUBE RUNNER", textScale,
-            {115, 235, 255});
-        drawText(surface, 26 * uiScale, 48 * uiScale,
-            "SCORE " + std::to_string(static_cast<int>(score)), textScale,
-            {245, 248, 255});
-
-        const std::string status =
-            "LIVES " + std::to_string(lives) + "   STAGE " + std::to_string(stage + 1);
-        const int statusWidth = static_cast<int>(status.size()) * 6 * textScale;
-        drawText(surface, surface.width - statusWidth - 18 * uiScale, 24 * uiScale,
-            status, textScale, {255, 225, 70});
-
-        const std::string fps =
-            "FPS " + std::to_string(std::max(0, static_cast<int>(framesPerSecond + 0.5f)));
-        const int fpsWidth = static_cast<int>(fps.size()) * 6 * textScale;
-        drawText(surface, surface.width - fpsWidth - 18 * uiScale, 48 * uiScale,
-            fps, textScale, {115, 235, 255});
-
         surface.fillRect(0, surface.height - 31 * uiScale, surface.width, 31 * uiScale,
             {2, 5, 11}, 0.72f);
-        const std::string controls =
-            "[A/D] OR DRAG TO STEER   [P] PAUSE   [R] RESTART";
-        const int controlsWidth = static_cast<int>(controls.size()) * 6 * uiScale;
-        drawText(surface, (surface.width - controlsWidth) / 2,
-            surface.height - 22 * uiScale, controls, uiScale,
+    }
+
+    template <typename Canvas>
+    void drawHudText(Canvas& canvas, const Surface& surface, float framesPerSecond) const
+    {
+        const int uiScale = hudScale(surface);
+        const int textScale = 2 * uiScale;
+        canvas.draw(26 * uiScale, 24 * uiScale, TEXT_HUD_TITLE, textScale, {115, 235, 255});
+        canvas.draw(26 * uiScale, 48 * uiScale,
+            std::string(TEXT_SCORE) + std::to_string(static_cast<int>(score)), textScale,
+            {245, 248, 255});
+
+        const std::string status = std::string(TEXT_LIVES) + std::to_string(lives)
+            + "   " + TEXT_STAGE + std::to_string(stage + 1);
+        const int statusWidth = canvas.width(status, textScale);
+        canvas.draw(surface.width - statusWidth - 18 * uiScale, 24 * uiScale,
+            status, textScale, {255, 225, 70});
+
+        const std::string fps = std::string(TEXT_FPS)
+            + std::to_string(std::max(0, static_cast<int>(framesPerSecond + 0.5f)));
+        const int fpsWidth = canvas.width(fps, textScale);
+        canvas.draw(surface.width - fpsWidth - 18 * uiScale, 48 * uiScale,
+            fps, textScale, {115, 235, 255});
+
+        const int controlsScale = uiScale;
+        const int controlsWidth = canvas.width(TEXT_CONTROLS, controlsScale);
+        canvas.draw((surface.width - controlsWidth) / 2,
+            surface.height - 22 * uiScale, TEXT_CONTROLS, controlsScale,
             {190, 220, 240}, false);
+    }
+
+    template <typename Canvas>
+    void drawOverlayText(Canvas& canvas, const Surface& surface) const
+    {
+        if (!paused && !gameOver) {
+            return;
+        }
+
+        const std::string message = gameOver ? TEXT_GAME_OVER : TEXT_PAUSED;
+        const int uiScale = hudScale(surface);
+        const int scale = 5 * uiScale;
+        const int messageWidth = canvas.width(message, scale);
+        const int messageY = static_cast<int>(surface.height * 0.40f);
+        canvas.draw((surface.width - messageWidth) / 2, messageY, message, scale,
+            gameOver ? Color {255, 80, 70} : Color {255, 220, 70});
+
+        const std::string action = gameOver ? TEXT_ACTION_RESTART : TEXT_ACTION_RESUME;
+        const int actionScale = 2 * uiScale;
+        const int actionWidth = canvas.width(action, actionScale);
+        canvas.draw((surface.width - actionWidth) / 2, messageY + 52 * uiScale,
+            action, actionScale, {220, 235, 255});
     }
 
     Random                random;
@@ -1324,6 +1454,13 @@ int main(int argc, char** argv)
             return EXIT_FAILURE;
         }
         argumentOffset = 2;
+    } else if (argc > 1 && argv[1][0] == '-') {
+        // Reject unknown options instead of silently treating them as the output
+        // filename, mirroring the interactive main's argument validation.
+        std::cerr << "Unknown argument: " << argv[1] << '\n';
+        std::cerr << "Usage: --self-test | --benchmark WIDTHxHEIGHT [frames]"
+                     " | --render WIDTHxHEIGHT [output.ppm] [frames] | [output.ppm]\n";
+        return EXIT_FAILURE;
     }
 
     const std::string outputPath = argc > argumentOffset + 1
@@ -1380,7 +1517,7 @@ int main(int argc, char** argv)
     }
 
     initgraph(width, height, INIT_ANIMATION);
-    setcaption("XEGE - Cube Runner");
+    setcaption(TEXT_WINDOW_TITLE);
     setrendermode(RENDER_MANUAL);
 
     auto closeWindow = [] {
@@ -1399,6 +1536,7 @@ int main(int argc, char** argv)
     }
     Surface surface(width, height);
     Game game;
+    EgeTextCanvas textCanvas;
     bool dragging = false;
     int lastMouseX = 0;
     int renderedFrames = 0;
@@ -1437,12 +1575,14 @@ int main(int argc, char** argv)
 
         const bool turnLeft  = keystate(key_left) || keystate(key_A);
         const bool turnRight = keystate(key_right) || keystate(key_D);
+        const float framesPerSecond = getfps();
         game.update(1.0f / 60.0f, turnLeft, turnRight, dragRotation);
-        game.render(surface, getfps());
+        game.render(surface, framesPerSecond);
 
         color_t* destination = getbuffer(frameImage);
         std::copy(surface.pixels.begin(), surface.pixels.end(), destination);
         putimage(0, 0, frameImage);
+        game.drawText(textCanvas, surface, framesPerSecond);
         ++renderedFrames;
         if (exitAfterFrames > 0 && renderedFrames >= exitAfterFrames) {
             break;

--- a/demo/game_cube_runner.cpp
+++ b/demo/game_cube_runner.cpp
@@ -24,14 +24,14 @@ constexpr int   kTracks      = 12;
 constexpr int   kTubeRows    = 24;
 constexpr float kPi          = 3.14159265358979323846f;
 constexpr float kTrackAngle  = 2.0f * kPi / kTracks;
-constexpr float kTileSize    = 2.0f * std::sin(kPi / kTracks);
+const     float kTileSize    = 2.0f * std::sin(kPi / kTracks);
 constexpr float kTubeRadius  = 1.0f;
 constexpr float kNearPlane   = 0.18f;
-constexpr float kFarPlane    = kTileSize * kTubeRows;
-constexpr float kFogNear     = kFarPlane * 0.25f;
+const     float kFarPlane    = kTileSize * kTubeRows;
+const     float kFogNear     = kFarPlane * 0.25f;
 constexpr float kCameraY     = -0.5f;
 constexpr float kPlayerAngle = -kPi * 0.5f;
-constexpr float kFocalLength = (kHeight * 0.5f) / std::tan(75.0f * kPi / 360.0f);
+const     float kFocalLength = (kHeight * 0.5f) / std::tan(75.0f * kPi / 360.0f);
 
 struct Vec3 {
     float x;


### PR DESCRIPTION
## Summary

- add a self-contained Cube Runner game under `demo/`
- render a curved 12-lane tunnel, obstacles, player, lighting, fog, and HUD entirely on the CPU
- include eight obstacle/stage patterns, collision handling, scoring, lives, pause, and restart controls
- keep the demo asset-free and compact enough for a 640 x 480 window
- include a headless build mode so the same renderer can produce deterministic validation frames

## Motivation

This demonstrates how XEGE can host a small 3D game without requiring a hardware-accelerated backend. The software rasterizer uses filled triangles, a depth buffer, fog, and lightweight face shading, making it useful both as a playable demo and as a reference for CPU-rendered 3D effects.

## Controls

- `A` / `D` or arrow keys: steer around the tunnel
- `P`: pause or resume
- `R`: restart
- `Esc`: exit

## Validation

- MinGW Release build of `game_cube_runner`
- MinGW Release build of the complete `demos` target
- MinGW Release default all-target build
- native headless build with `-Wall -Wextra -Wpedantic`
- headless runtime validation with AddressSanitizer and UndefinedBehaviorSanitizer
- deterministic 640 x 480 render inspected visually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增无需外部资源的 Cube Runner 3D 方块跑酷游戏。
  * 支持键盘与鼠标转向、暂停、重置、碰撞检测、生命值、无敌时间及等级推进。
  * 提供随机障碍、弯曲隧道、雾效、抗锯齿渲染和 HUD 信息。
  * 支持自定义分辨率与退出帧数，并提供帮助提示和错误处理。

* **开发体验**
  * 新增 Debug 和 Release 模式的一键构建运行任务。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->