### PR TITLE
ci: 移除已退役的 windows-2019 runner，修复 master 分支 CI 卡死

### DIFF
--- a/.github/release-assets/WORKFLOW_USAGE.md
+++ b/.github/release-assets/WORKFLOW_USAGE.md
@@ -82,8 +82,7 @@ When master branch is updated (not a tag push), a test release is automatically 
 
 **MSVC 库:**
 - VS2022 (toolset v143) - Windows latest
-- VS2019 (toolset v142) - Windows 2019
-- VS2017 (toolset v141) - Windows 2019
+- VS2019 (toolset v142) - Windows latest
 
 **MinGW Windows 库:**
 - MSYS2 最新版 (GCC 最新版) / MSYS2 Latest (GCC Latest Version)

--- a/.github/release-assets/WORKFLOW_USAGE.md
+++ b/.github/release-assets/WORKFLOW_USAGE.md
@@ -126,7 +126,6 @@ ege-{version}/
 ├── lib/                     # 库文件 / Library files
 │   ├── vs2022/x64/         # Visual Studio 2022
 │   ├── vs2019/x64/         # Visual Studio 2019
-│   ├── vs2017/x64/         # Visual Studio 2017
 │   ├── mingw64/            # MinGW MSYS2
 │   ├── codeblocks/         # Code::Blocks
 │   ├── redpanda/           # CLion/小熊猫C++

--- a/.github/workflows/msvc-build.yml
+++ b/.github/workflows/msvc-build.yml
@@ -120,61 +120,9 @@ jobs:
           cd build-vs2019
           cmake --build . --config ${{ matrix.build_type }} --parallel
 
-  # VS2015-2017 使用 windows-2019 runner（预装了 v140 和 v141 工具集）
-  vs2017-build:
-    name: MSVC 2017 Build (${{ matrix.build_type }})
-    runs-on: windows-2019
-    strategy:
-      matrix:
-        build_type: ["Release", "Debug"]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      
-      - name: Setup Visual Studio environment
-        uses: microsoft/setup-msbuild@v1.1
-
-      - name: Configure CMake
-        run: |
-          mkdir build-vs2017
-          cd build-vs2017
-          cmake .. -T v141 -DEGE_BUILD_DEMO=ON # vs2017
-
-      - name: Build
-        env:
-          DO_TEST_RELEASE_LIBS: true
-        run: |
-          cd build-vs2017
-          cmake --build . --config ${{ matrix.build_type }} --parallel
-
-  vs2015-build:
-    name: MSVC 2015 Build (${{ matrix.build_type }})
-    runs-on: windows-2019
-    strategy:
-      matrix:
-        build_type: ["Release", "Debug"]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      
-      - name: Setup Visual Studio environment
-        uses: microsoft/setup-msbuild@v1.1
-
-      - name: Configure CMake
-        run: |
-          mkdir build-vs2015
-          cd build-vs2015
-          cmake .. -T v140 # vs2015
-
-      - name: Build
-        env:
-          DO_TEST_RELEASE_LIBS: true
-        run: |
-          cd build-vs2015
-          cmake --build . --config ${{ matrix.build_type }} --parallel
-
-  # 注意：VS2010-VS2013 (v100-v120) 已从 CI 中移除
-  # 原因：Chocolatey 已移除这些旧版本的 build tools 包，且微软官方也不再提供独立安装程序
-  # 这些编译器版本已超过 10 年，现代 GitHub Actions runner 不再支持
+  # 注意：VS2015 (v140) / VS2017 (v141) / VS2010-VS2013 (v100-v120) 已从 CI 中移除
+  # 原因：
+  #   1. GitHub 已于 2025-06-30 退役 windows-2019 runner 镜像，而 v140/v141 工具集
+  #      原本依赖该镜像预装；改用 windows-latest 后需手动安装，脆弱且缓慢。
+  #   2. Chocolatey 已移除 v100-v120 的 build tools 包，微软官方也不再提供独立安装程序。
+  # 这些编译器版本已超过 8 年，库本身仍兼容，只是 CI 不再覆盖。

--- a/.github/workflows/msvc-build.yml
+++ b/.github/workflows/msvc-build.yml
@@ -7,6 +7,9 @@ on:
     # 所有分支的 PR 都触发
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   vs2026-build:
     name: MSVC 2026 Build (${{ matrix.build_type }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,56 +192,36 @@ jobs:
             cmake_arch: Win32
           
           # VS2019 - x64 and x86, Debug and Release
+          # 注意: v142 工具集在 windows-latest (VS2022) 上已预装，无需 windows-2019 镜像
+          # (windows-2019 已于 2025-06-30 被 GitHub 退役)
           - name: VS2019
-            os: windows-2019
+            os: windows-latest
             toolset: v142
             arch: x64
             config: Release
             cmake_arch: x64
           - name: VS2019
-            os: windows-2019
+            os: windows-latest
             toolset: v142
             arch: x64
             config: Debug
             cmake_arch: x64
           - name: VS2019
-            os: windows-2019
+            os: windows-latest
             toolset: v142
             arch: x86
             config: Release
             cmake_arch: Win32
           - name: VS2019
-            os: windows-2019
+            os: windows-latest
             toolset: v142
             arch: x86
             config: Debug
             cmake_arch: Win32
-          
-          # VS2017 - x64 and x86, Debug and Release
-          - name: VS2017
-            os: windows-2019
-            toolset: v141
-            arch: x64
-            config: Release
-            cmake_arch: x64
-          - name: VS2017
-            os: windows-2019
-            toolset: v141
-            arch: x64
-            config: Debug
-            cmake_arch: x64
-          - name: VS2017
-            os: windows-2019
-            toolset: v141
-            arch: x86
-            config: Release
-            cmake_arch: Win32
-          - name: VS2017
-            os: windows-2019
-            toolset: v141
-            arch: x86
-            config: Debug
-            cmake_arch: Win32
+
+          # 注意：VS2017 (v141) / VS2015 (v140) 已从 release matrix 中移除
+          # 原因：windows-2019 runner 镜像已于 2025-06-30 被 GitHub 退役，
+          # 而 v141/v140 工具集在 windows-latest 上未预装、手动安装脆弱且缓慢。
     
     runs-on: ${{ matrix.os }}
     


### PR DESCRIPTION
## 背景

master 分支的 **MSVC Build** 与 **Release Package** 两个 workflow 一直失败，报错：

```
The job has exceeded the maximum execution time while awaiting a runner for 24h0m0s
```

## 根因

GitHub 已于 **2025-06-30 退役 `windows-2019` runner 镜像**，但以下两个 PR 重新引入了对该镜像的依赖，导致相关 job 永远等不到 runner、卡满 24h 超时：

- #349（2025-12-14）→ `msvc-build.yml` 的 vs2015/vs2017 job 使用 `runs-on: windows-2019`
- #355（2025-12-14）→ `release.yml` 的 VS2019/VS2017 matrix 使用 `os: windows-2019`

> 仓库此前在 1a857ba 已正确修复过一次（改用 `windows-latest` 并移除 vs2015 job），被上述 PR 改回。

## 修复

| 文件 | 改动 |
|------|------|
| `msvc-build.yml` | 删除 `vs2017-build`、`vs2015-build` 两个 job |
| `release.yml` | VS2019 matrix 改用 `windows-latest`（v142 在 VS2022 镜像上已预装）；删除 VS2017 matrix 条目 |

### 关于 VS2015 (v140) / VS2017 (v141) 的移除

这两个旧工具集在 `windows-latest` 上未预装，手动安装脆弱且缓慢。库本身仍兼容老工具链，只是 CI 不再覆盖。VS2019 (v142) 直接换 `windows-latest` 即可，无需额外处理。

## 验证

- YAML 语法校验通过
- 净删 88 行、加 16 行（基本为注释）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **构建与发布**
  * 更新 Windows 构建环境，使用新版运行器执行 Visual Studio 2019 构建。
  * 移除已退役或难以维护的旧版 Visual Studio 构建配置。
  * 保留 Visual Studio 2019、2022 和 2026 的现有构建任务及配置。
  * 更新构建库说明，反映最新的 Visual Studio 版本支持情况。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->