### PR TITLE
fix(release): 打包循环移除 VS2017，修复 Release Package 失败

### DIFF
--- a/.github/release-assets/README.md
+++ b/.github/release-assets/README.md
@@ -41,7 +41,6 @@ ege-25.11/
 ├── lib/                    # 静态库
 │   ├── vs2022/x64/         # Visual Studio 2022 静态库
 │   ├── vs2019/x64/         # Visual Studio 2019 静态库
-│   ├── vs2017/x64/         # Visual Studio 2017 静态库
 │   ├── mingw64/            # MinGW-w64 (MSYS2) 静态库
 │   ├── codeblocks/         # Code::Blocks 25.03 静态库
 │   ├── redpanda/           # CLion/小熊猫C++ 静态库

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -546,7 +546,7 @@ jobs:
           
           # MSVC libraries - now with Debug/Release and x86/x64
           # Artifacts are named: libs-VS2022-x64-Release, libs-VS2022-x64-Debug, etc.
-          for vsname in VS2022 VS2019 VS2017; do
+          for vsname in VS2022 VS2019; do
             vsdir=$(echo "$vsname" | tr '[:upper:]' '[:lower:]')
             
             for arch in x64 x86; do
@@ -667,7 +667,7 @@ jobs:
             - **doc/** - 文档
             - **include/** - 头文件
             - **lib/** - 静态库文件
-              - vs2022/vs2019/vs2017 - Visual Studio 静态库 (x86/x64, Debug/Release)
+              - vs2022/vs2019 - Visual Studio 静态库 (x86/x64, Debug/Release)
               - mingw64 - MinGW-w64 (MSYS2) 静态库 (x64)
               - codeblocks - Code::Blocks 25.03 静态库 (x64)
               - redpanda - CLion/小熊猫C++ (RedPanda C++) 静态库 (x64)


### PR DESCRIPTION
## 问题

#377 合入后，master 的 **Release Package** workflow 失败（此前 MSVC Build / MinGW 均已恢复）。

失败点：`Create Release Package` → `Organize MSVC libraries`

```
for vsname in VS2022 VS2019 VS2017; do
  ...
  if [ -d "$artifact_dir" ]; then ... else
    echo "ERROR: Artifact directory $artifact_dir not found"
    exit 1
  fi
```

#377 从构建 matrix 移除了 VS2017，但打包循环仍硬编码遍历 VS2017，找不到对应 artifact 目录后 `exit 1`。这是 #377 的遗漏，本 PR 修复。

## 修复

- `release.yml`：打包循环 `VS2022 VS2019 VS2017` → `VS2022 VS2019`；Release 说明的"包含内容"列表同步去掉 vs2017
- `README.md`：发布包目录结构移除 `vs2017/x64/`

## 保留项

`CMakeLists.txt` 中按编译器版本自动选择 `lib/vs2017/` 的运行时逻辑保留——库本身仍兼容 VS2017，只是 CI / 发布包不再预编译该版本，用户本地有 VS2017 时仍可自行编译使用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)