### PR TITLE
Extract backend-independent reliability fixes

### DIFF
--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -122,9 +122,10 @@ if(NOT CMAKE_HOST_UNIX)
   # If the exclusion is intended for specific Unix-like environments, refine the condition below.
   message(STATUS "Finding GMP Library")
   find_path(GMPXX_INCLUDE_DIR NAMES gmpxx.h)
+  find_library(GMPXX_LIBRARY NAMES gmpxx)
   find_library(GMP_LIBRARY NAMES gmp)
 
-  if(GMPXX_INCLUDE_DIR AND GMP_LIBRARY)
+  if(GMPXX_INCLUDE_DIR AND GMPXX_LIBRARY AND GMP_LIBRARY)
     message(STATUS "GMP Library found")
     file(
       GLOB GMP_DEMO_SRCS
@@ -137,7 +138,7 @@ if(NOT CMAKE_HOST_UNIX)
       get_filename_component(DEMO_NAME ${GMP_DEMO_SRC} NAME_WE)
       ege_add_executable_demo(${DEMO_NAME} ${GMP_DEMO_SRC})
       target_include_directories(${DEMO_NAME} PRIVATE ${GMPXX_INCLUDE_DIR})
-      target_link_libraries(${DEMO_NAME} ${GMP_LIBRARY})
+      target_link_libraries(${DEMO_NAME} ${GMPXX_LIBRARY} ${GMP_LIBRARY})
     endforeach()
   else()
     message(STATUS "GMP Library not found")

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -121,9 +121,10 @@ if(NOT CMAKE_HOST_UNIX)
   # GMP demos are excluded on Unix hosts due to compatibility issues or specific requirements.
   # If the exclusion is intended for specific Unix-like environments, refine the condition below.
   message(STATUS "Finding GMP Library")
-  find_library(gmp gmp)
+  find_path(GMPXX_INCLUDE_DIR NAMES gmpxx.h)
+  find_library(GMP_LIBRARY NAMES gmp)
 
-  if(gmp)
+  if(GMPXX_INCLUDE_DIR AND GMP_LIBRARY)
     message(STATUS "GMP Library found")
     file(
       GLOB GMP_DEMO_SRCS
@@ -135,7 +136,8 @@ if(NOT CMAKE_HOST_UNIX)
     foreach(GMP_DEMO_SRC ${GMP_DEMO_SRCS})
       get_filename_component(DEMO_NAME ${GMP_DEMO_SRC} NAME_WE)
       ege_add_executable_demo(${DEMO_NAME} ${GMP_DEMO_SRC})
-      target_link_libraries(${DEMO_NAME} gmp)
+      target_include_directories(${DEMO_NAME} PRIVATE ${GMPXX_INCLUDE_DIR})
+      target_link_libraries(${DEMO_NAME} ${GMP_LIBRARY})
     endforeach()
   else()
     message(STATUS "GMP Library not found")

--- a/demo/graph_clock.cpp
+++ b/demo/graph_clock.cpp
@@ -47,7 +47,7 @@ void draw()
 	{
 		char str[8];
 		ege::ege_point p = getpos(center, float(num * pi2 / 12), r);
-		sprintf(str, "%d", num);
+		snprintf(str, sizeof(str), "%d", num);
 		ege::outtextxy((int)p.x, (int)p.y, str);
 	}
 
@@ -57,7 +57,7 @@ void draw()
 	ege::setcolor(EGEARGB(0xff, 0x0, 0x0, 0xff));
 	ege::setlinewidth(10.0f);
 
-    char str[32];
+    char str[64];
     ege::ege_point p;
 
     float h = float(t->tm_hour + t->tm_min / 60.0);
@@ -81,7 +81,7 @@ void draw()
     ege::ege_fillellipse(center.x - r * 0.05f, center.y - r * 0.05f,
         r * 0.1f, r * 0.1f);
 
-    sprintf(str, "%d/%02d/%02d %2d:%02d:%02d",
+    snprintf(str, sizeof(str), "%d/%02d/%02d %2d:%02d:%02d",
         t->tm_year + 1900, t->tm_mon + 1, t->tm_mday,
         t->tm_hour, t->tm_min, t->tm_sec);
     ege::setcolor(EGERGB(0xff, 0xff, 0));
@@ -119,4 +119,3 @@ int main()
 	ege::closegraph();
 	return 0;
 }
-

--- a/include/ege/button.h
+++ b/include/ege/button.h
@@ -112,7 +112,6 @@ public:
     button(CTL_DEFPARAM) : CTL_INITBASE(egeControlBase)
     {
         CTL_INIT; // must be the first line
-        size(64, 32);
         _caption[0]   = '\0';
         _font_height = 12;
 #if defined(_MSC_VER) && (_MSC_VER >= 1400)
@@ -126,8 +125,6 @@ public:
         _text_color   = BLACK;
         _shadow_color = EGERGB(50, 50, 50);
 
-        updatesidewidth();
-
         _on_click      = NULL;
         callback_param = NULL;
         _pushed        = false;
@@ -135,6 +132,9 @@ public:
 #ifdef DEBUG
         _logger = NULL;
 #endif
+        // size() dispatches to button::onSize(), which redraws the control.
+        // Initialize every property consumed by redraw() first.
+        size(64, 32);
         // redraw();
         // blendmode(true);
     }

--- a/include/ege/label.h
+++ b/include/ege/label.h
@@ -21,6 +21,7 @@ public:
     {
         CTL_INIT; // must be the first line
         size(64, 16);
+        m_caption[0]  = '\0';
         m_color       = WHITE;
         m_bkcolor     = BLACK;
         m_fontheight  = 12;

--- a/src/camera_capture.cpp
+++ b/src/camera_capture.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "camera_frame_copy.h"
 #include "image.h"
 
 using namespace ccap;
@@ -77,10 +78,7 @@ public:
 
     PIMAGE getImage() override
     {
-        // 检查是否需要更新图像数据：
-        // 1. m_frame != m_realFrame.get() 表示帧数据已更新（新帧或帧被复用）
-        // 2. m_realImage == nullptr 表示图像尚未创建
-        if ((m_frame != m_realFrame.get() || m_realImage == nullptr) && m_realFrame) {
+        if (m_realFrame) {
             if (m_realFrame->pixelFormat != ccap::PixelFormat::BGRA32) {
                 fputs("ege: 抓取到的图像格式不正确, 请上报一个错误!!", stderr);
                 fputs("ege: The captured image format is incorrect, please report an error!!", stderr);
@@ -88,23 +86,32 @@ public:
                 return nullptr;
             }
 
-            // 更新一下数据.
-            m_frame = m_realFrame.get();
-            if (!m_realImage) {
-                m_realImage = std::make_shared<ege::IMAGE>(m_realFrame->width, m_realFrame->height, ege::BLACK);
+            const detail::BgraFrameView frameView = {
+                m_realFrame->data[0], m_realFrame->sizeInBytes,
+                m_realFrame->width, m_realFrame->height, m_realFrame->stride[0]
+            };
+            std::size_t imageBytes = 0;
+            if (!detail::validateBgraFrameLayout(frameView, nullptr, &imageBytes)) {
+                fputs("ege: captured BGRA frame has invalid dimensions, stride, or data size\n", stderr);
+                return nullptr;
             }
 
-            auto* img    = m_realImage.get();
-            auto* buffer = img->getbuffer();
-
-            if (m_realFrame->width * 4 == m_realFrame->stride[0]) { // 已对齐
-                assert(m_realFrame->sizeInBytes >= m_realFrame->width * m_realFrame->height * 4);
-                memcpy(buffer, m_realFrame->data[0], m_realFrame->sizeInBytes);
-            } else { // 未对齐
-                for (uint32_t i = 0; i < m_realFrame->height; ++i) {
-                    memcpy(buffer + i * m_realFrame->width, m_realFrame->data[0] + i * m_realFrame->stride[0],
-                        m_realFrame->width * 4);
+            const bool imageSizeChanged = m_realImage &&
+                (m_realImage->getwidth() != static_cast<int>(m_realFrame->width) ||
+                 m_realImage->getheight() != static_cast<int>(m_realFrame->height));
+            if (m_frame != m_realFrame.get() || !m_realImage || imageSizeChanged) {
+                std::shared_ptr<ege::IMAGE> image = m_realImage;
+                if (!image || imageSizeChanged) {
+                    image = std::make_shared<ege::IMAGE>(
+                        static_cast<int>(m_realFrame->width),
+                        static_cast<int>(m_realFrame->height), ege::BLACK);
                 }
+                if (!detail::copyBgraFramePixels(image->getbuffer(), imageBytes, frameView)) {
+                    fputs("ege: failed to copy captured BGRA frame pixels\n", stderr);
+                    return nullptr;
+                }
+                m_realImage = std::move(image);
+                m_frame     = m_realFrame.get();
             }
         }
 
@@ -125,15 +132,22 @@ public:
                 return m_realImage.get();
             }
 
-            PIMAGE img    = new ege::IMAGE(m_realFrame->width, m_realFrame->height, ege::BLACK);
-            auto*  buffer = img->getbuffer();
-            if (m_realFrame->width * 4 == m_realFrame->stride[0]) { // 已对齐
-                memcpy(buffer, m_realFrame->data[0], m_realFrame->sizeInBytes);
-            } else { // 未对齐
-                for (uint32_t i = 0; i < m_realFrame->height; ++i) {
-                    memcpy(buffer + i * m_realFrame->width, m_realFrame->data[0] + i * m_realFrame->stride[0],
-                        m_realFrame->width * 4);
-                }
+            const detail::BgraFrameView frameView = {
+                m_realFrame->data[0], m_realFrame->sizeInBytes,
+                m_realFrame->width, m_realFrame->height, m_realFrame->stride[0]
+            };
+            std::size_t imageBytes = 0;
+            if (!detail::validateBgraFrameLayout(frameView, nullptr, &imageBytes)) {
+                fputs("ege: captured BGRA frame has invalid dimensions, stride, or data size\n", stderr);
+                return nullptr;
+            }
+
+            PIMAGE img = new ege::IMAGE(static_cast<int>(m_realFrame->width),
+                                        static_cast<int>(m_realFrame->height), ege::BLACK);
+            if (!detail::copyBgraFramePixels(img->getbuffer(), imageBytes, frameView)) {
+                delete img;
+                fputs("ege: failed to copy captured BGRA frame pixels\n", stderr);
+                return nullptr;
             }
             return img;
         }

--- a/src/camera_frame_copy.cpp
+++ b/src/camera_frame_copy.cpp
@@ -1,0 +1,94 @@
+#include "camera_frame_copy.h"
+
+#include <climits>
+#include <cstring>
+#include <limits>
+
+namespace ege
+{
+namespace detail
+{
+
+bool validateBgraFrameLayout(const BgraFrameView& frame,
+                             size_t* rowBytes,
+                             size_t* imageBytes)
+{
+    if (rowBytes) {
+        *rowBytes = 0;
+    }
+    if (imageBytes) {
+        *imageBytes = 0;
+    }
+    if (!frame.data || frame.width == 0 || frame.height == 0 ||
+        frame.width > static_cast<uint32_t>(INT_MAX) ||
+        frame.height > static_cast<uint32_t>(INT_MAX))
+    {
+        return false;
+    }
+
+    const size_t width = frame.width;
+    const size_t height = frame.height;
+    const size_t bytesPerPixel = 4;
+    if (width > std::numeric_limits<size_t>::max() / bytesPerPixel) {
+        return false;
+    }
+    const size_t activeRowBytes = width * bytesPerPixel;
+    if (height > std::numeric_limits<size_t>::max() / activeRowBytes) {
+        return false;
+    }
+    const size_t packedImageBytes = activeRowBytes * height;
+
+    // IMAGE still contains legacy int arithmetic for pixel and byte counts.
+    // Reject frames that cannot safely pass through those paths before an
+    // IMAGE allocation is attempted.
+    if (packedImageBytes > static_cast<size_t>(INT_MAX)) {
+        return false;
+    }
+
+    const size_t sourceStride = frame.stride;
+    if (sourceStride < activeRowBytes) {
+        return false;
+    }
+    const size_t precedingRows = height - 1;
+    if (precedingRows >
+        (std::numeric_limits<size_t>::max() - activeRowBytes) / sourceStride)
+    {
+        return false;
+    }
+    const size_t requiredSourceBytes = precedingRows * sourceStride + activeRowBytes;
+    if (frame.dataSize < requiredSourceBytes) {
+        return false;
+    }
+
+    if (rowBytes) {
+        *rowBytes = activeRowBytes;
+    }
+    if (imageBytes) {
+        *imageBytes = packedImageBytes;
+    }
+    return true;
+}
+
+bool copyBgraFramePixels(void* destination,
+                         size_t destinationSize,
+                         const BgraFrameView& frame)
+{
+    size_t rowBytes = 0;
+    size_t imageBytes = 0;
+    if (!validateBgraFrameLayout(frame, &rowBytes, &imageBytes) ||
+        !destination || destinationSize < imageBytes)
+    {
+        return false;
+    }
+
+    unsigned char* output = static_cast<unsigned char*>(destination);
+    for (size_t y = 0; y < frame.height; ++y) {
+        std::memcpy(output + y * rowBytes,
+                    frame.data + y * static_cast<size_t>(frame.stride),
+                    rowBytes);
+    }
+    return true;
+}
+
+} // namespace detail
+} // namespace ege

--- a/src/camera_frame_copy.h
+++ b/src/camera_frame_copy.h
@@ -1,0 +1,33 @@
+#ifndef EGE_CAMERA_FRAME_COPY_H
+#define EGE_CAMERA_FRAME_COPY_H
+
+#include <stddef.h>
+
+#include "ege/stdint.h"
+
+namespace ege
+{
+namespace detail
+{
+
+struct BgraFrameView
+{
+    const unsigned char* data;
+    size_t               dataSize;
+    uint32_t             width;
+    uint32_t             height;
+    uint32_t             stride;
+};
+
+bool validateBgraFrameLayout(const BgraFrameView& frame,
+                             size_t* rowBytes,
+                             size_t* imageBytes);
+
+bool copyBgraFramePixels(void* destination,
+                         size_t destinationSize,
+                         const BgraFrameView& frame);
+
+} // namespace detail
+} // namespace ege
+
+#endif

--- a/tests/native/CMakeLists.txt
+++ b/tests/native/CMakeLists.txt
@@ -34,6 +34,9 @@ target_compile_definitions(ege_native_public_headers_zh PRIVATE EGE_TEST_ZH_HEAD
 ege_add_native_test(ege_native_pixel_surface native.pixel_surface
     pixel_surface_test.cpp)
 
+ege_add_native_test(ege_native_camera_frame_copy native.camera_frame_copy
+    camera_frame_copy_test.cpp)
+
 ege_add_native_test(ege_native_raster_image_contract
     native.ege_raster_image_contract
     ege_raster_image_contract_test.cpp)

--- a/tests/native/camera_frame_copy_test.cpp
+++ b/tests/native/camera_frame_copy_test.cpp
@@ -1,0 +1,148 @@
+#include "camera_frame_copy.h"
+
+#include <algorithm>
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+int failures = 0;
+
+void expect(bool condition, const std::string& message)
+{
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+bool bytesEqual(const unsigned char* lhs, const unsigned char* rhs,
+                std::size_t count)
+{
+    return std::memcmp(lhs, rhs, count) == 0;
+}
+
+bool bytesAre(const unsigned char* bytes, std::size_t count,
+              unsigned char value)
+{
+    return std::all_of(bytes, bytes + count,
+        [value](unsigned char byte) { return byte == value; });
+}
+
+} // namespace
+
+int main()
+{
+    using ege::detail::BgraFrameView;
+    using ege::detail::copyBgraFramePixels;
+    using ege::detail::validateBgraFrameLayout;
+
+    std::vector<unsigned char> paddedSource(32);
+    for (std::size_t i = 0; i < paddedSource.size(); ++i) {
+        paddedSource[i] = static_cast<unsigned char>(i + 1);
+    }
+    const BgraFrameView padded = {
+        paddedSource.data(), paddedSource.size(), 3, 2, 16};
+
+    std::size_t rowBytes = 0;
+    std::size_t imageBytes = 0;
+    expect(validateBgraFrameLayout(padded, &rowBytes, &imageBytes),
+           "a padded two-row BGRA frame has a valid layout");
+    expect(rowBytes == 12 && imageBytes == 24,
+           "layout reports active row and destination byte counts");
+
+    std::vector<unsigned char> paddedDestination(imageBytes + 8, 0xA5);
+    expect(copyBgraFramePixels(paddedDestination.data(), imageBytes, padded),
+           "padded-stride frame copies successfully");
+    expect(bytesEqual(paddedDestination.data(), paddedSource.data(), rowBytes),
+           "the first active row is copied without padding");
+    expect(bytesEqual(paddedDestination.data() + rowBytes,
+                      paddedSource.data() + padded.stride, rowBytes),
+           "the second active row starts at the source stride");
+    expect(bytesAre(paddedDestination.data() + imageBytes, 8, 0xA5),
+           "padded-stride copy does not overwrite the destination guard");
+
+    std::vector<unsigned char> tightSource(24);
+    for (std::size_t i = 0; i < tightSource.size(); ++i) {
+        tightSource[i] = static_cast<unsigned char>(0x40 + i);
+    }
+    const BgraFrameView tightWithTrailingBytes = {
+        tightSource.data(), tightSource.size(), 2, 2, 8};
+    std::vector<unsigned char> tightDestination(24, 0x5A);
+    expect(copyBgraFramePixels(
+               tightDestination.data(), 16, tightWithTrailingBytes),
+           "tight-stride frame tolerates provider-owned trailing bytes");
+    expect(bytesEqual(tightDestination.data(), tightSource.data(), 16),
+           "tight-stride frame copies exactly the active pixels");
+    expect(bytesAre(tightDestination.data() + 16, 8, 0x5A),
+           "tight-stride copy never copies provider trailing bytes");
+
+    std::vector<unsigned char> unchanged(24, 0xCC);
+    BgraFrameView invalid = padded;
+    invalid.stride = 11;
+    expect(!copyBgraFramePixels(unchanged.data(), unchanged.size(), invalid),
+           "stride shorter than an active row is rejected");
+    expect(bytesAre(unchanged.data(), unchanged.size(), 0xCC),
+           "invalid stride leaves the destination untouched");
+
+    invalid = padded;
+    invalid.dataSize = 27;
+    expect(!copyBgraFramePixels(unchanged.data(), unchanged.size(), invalid),
+           "a truncated final source row is rejected");
+    expect(bytesAre(unchanged.data(), unchanged.size(), 0xCC),
+           "truncated source leaves the destination untouched");
+
+    invalid = padded;
+    invalid.data = nullptr;
+    expect(!validateBgraFrameLayout(invalid, nullptr, nullptr),
+           "a null source pointer is rejected");
+    expect(!copyBgraFramePixels(unchanged.data(), 23, padded),
+           "a destination smaller than the packed image is rejected");
+    expect(bytesAre(unchanged.data(), unchanged.size(), 0xCC),
+           "a short destination leaves all bytes untouched");
+
+    invalid = padded;
+    invalid.width = 0;
+    expect(!validateBgraFrameLayout(invalid, nullptr, nullptr),
+           "zero width is rejected");
+    invalid = padded;
+    invalid.height = 0;
+    expect(!validateBgraFrameLayout(invalid, nullptr, nullptr),
+           "zero height is rejected");
+
+    unsigned char dummy = 0;
+    const std::uint32_t aboveIntMax =
+        static_cast<std::uint32_t>(INT_MAX) + 1u;
+    const BgraFrameView tooWide = {
+        &dummy, std::numeric_limits<std::uint32_t>::max(), aboveIntMax, 1,
+        std::numeric_limits<std::uint32_t>::max()};
+    expect(!validateBgraFrameLayout(tooWide, nullptr, nullptr),
+           "width that IMAGE cannot represent is rejected");
+
+    const BgraFrameView tooTall = {
+        &dummy, std::numeric_limits<std::uint32_t>::max(), 1, aboveIntMax, 4};
+    expect(!validateBgraFrameLayout(tooTall, nullptr, nullptr),
+           "height that IMAGE cannot represent is rejected");
+
+    const BgraFrameView imageByteCountOverflowsInt = {
+        &dummy, std::numeric_limits<std::uint32_t>::max(),
+        32768, 16384, 131072};
+    expect(!validateBgraFrameLayout(
+               imageByteCountOverflowsInt, nullptr, nullptr),
+           "a byte count that overflows IMAGE internals is rejected");
+
+    if (failures != 0) {
+        std::cerr << failures << " camera frame copy assertion(s) failed\n";
+        return EXIT_FAILURE;
+    }
+    std::cout << "All camera frame copy assertions passed\n";
+    return EXIT_SUCCESS;
+}

--- a/tests/tests/putimage_performance_test.cpp
+++ b/tests/tests/putimage_performance_test.cpp
@@ -341,7 +341,9 @@ int main() {
     testFramework.printResults();    // 保存结果到文件
     testFramework.saveResultsToFile("putimage_performance_results.txt");
     
-    // 清理
+    // Release global image owners before the framework tears down graphics.
+    cleanupDestinationImage();
+    imageManager.cleanup();
     testFramework.cleanup();
 
     std::cout << "\nAll tests completed!" << std::endl;


### PR DESCRIPTION
## Summary

Extract backend-independent reliability improvements from the retired OpenGL experimental branches without bringing the OpenGL backend, its build paths, or its CPU/GPU synchronization model into `master`.

## Why these changes belong independently

The OpenGL work included a number of issues that are also present in the existing GDI/CoreGraphics code paths. They are independent of rendering-backend selection and improve correctness, safety, or developer ergonomics on the current mainline.

### Camera frame-copy safety

`CameraFrame::getImage()` and `copyImage()` previously assumed that captured BGRA data was tightly packed or that `sizeInBytes` could be copied wholesale into an `IMAGE` buffer. A camera provider may expose padded rows, trailing bytes, incomplete data, or a frame-size change. The new internal helper validates the dimensions, stride, source size, and legacy `IMAGE` size limits, then copies only active pixels one row at a time. It also recreates the cached `IMAGE` when the frame dimensions change.

This is production code used by camera capture, not test-only code. The accompanying unit test verifies padding, truncated input, undersized destinations, invalid dimensions, and integer-overflow boundaries without requiring a camera device.

### Control initialization

`button::size()` invokes `onSize()` and redraws the control. Initializing the size before the fields used by redraw allowed the constructor to read uninitialized state. The change initializes those fields first. The related `label` initialization now initializes its caption before its first redraw.

### Small independent correctness improvements

- Detect both the GMP C++ header and library before enabling GMP demos.
- Use bounded formatting in the clock demo.
- Release global performance-test images before graphics teardown, avoiding static-destruction-order dependence.

## Validation

- Configured and built the native macOS/CoreGraphics target with camera capture enabled.
- Ran the complete non-window native test suite: **18/18 passed**.
- The new `native.camera_frame_copy` unit test passed.
- Ran `git diff --check`.

## Scope intentionally excluded

This PR deliberately excludes the OpenGL backend, OpenGL-specific tests and diagnostics, GPU/CPU pixel synchronization code, and legacy OpenGL-oriented CI configuration. It also does not modify or delete any of the archived experimental branches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 改进摄像头图像帧处理，支持不同步幅，并在数据布局异常、尺寸无效或缓冲区不足时安全失败。
  - 修复按钮和标签初始化过程中的显示问题。
  - 改进图形时钟文本格式化，降低缓冲区溢出风险。
  - 修复性能测试退出时的资源释放问题。

- **构建**
  - 改进 GMP 示例的依赖检测与链接配置。

- **测试**
  - 新增摄像头帧复制测试，覆盖正常复制、行填充及多种无效输入场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->