### PR TITLE
fix: 修复了 resizewindow 部分情况下不触发窗口重绘的 BUG

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -262,6 +262,8 @@ void EGEAPI resizewindow(int width, int height)
         pg->getNativeWindow()->setSize(width, height);
     }
 #endif
+
+    pg->update_mark_count = 0;
 }
 
 int attachHWND(HWND hWnd)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复窗口调整大小后更新标记未正确重置的问题，提升窗口重绘和刷新行为的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->